### PR TITLE
chore: 이슈 닫기 워크플로우 추가

### DIFF
--- a/.github/workflows/pr-merge-cleanup.yml
+++ b/.github/workflows/pr-merge-cleanup.yml
@@ -30,11 +30,32 @@ jobs:
         shell: bash
         run: |
           echo "🔍 PR 내용에서 이슈 닫는 키워드를 찾는 중..."
-          printf '%s' "$PR_BODY" | tr -d '\r' | grep -Eoi '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | while read -r match; do
-            issue_number=$(echo "$match" | grep -oE '#[0-9]+' | tr -d '#')
-            echo "➡️  닫는 중: #$issue_number"
-            gh issue close "$issue_number" --reason completed --repo "$GITHUB_REPOSITORY"
-          done
+          issue_count=0
+          failed_count=0
+
+          # 이슈 번호 추출 및 중복 제거
+          issue_numbers=$(printf '%s' "$PR_BODY" | tr -d '\r' | grep -Eoi '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+
+          if [ -z "$issue_numbers" ]; then
+            echo "ℹ️  PR 본문에서 닫을 이슈를 찾지 못했습니다."
+            exit 0
+          fi
+
+          # 각 이슈 처리
+          while IFS= read -r issue_number; do
+            if [ -n "$issue_number" ]; then
+              echo "➡️  닫는 중: #$issue_number"
+              if gh issue close "$issue_number" --reason completed --repo "$GITHUB_REPOSITORY"; then
+                echo "✅ 이슈 #$issue_number 닫기 완료"
+                issue_count=$((issue_count + 1))
+              else
+                echo "⚠️  이슈 #$issue_number 닫기 실패 (이슈가 존재하지 않거나 권한이 없을 수 있습니다)"
+                failed_count=$((failed_count + 1))
+              fi
+            fi
+          done <<< "$issue_numbers"
+
+          echo "📊 처리 결과: 성공 $issue_count개, 실패 $failed_count개"
 
       - name: Delete source branch
         env:
@@ -44,4 +65,3 @@ jobs:
         run: |
           echo "🗑️  소스 브랜치 삭제 중: $BRANCH_NAME"
           gh api repos/${{ github.repository }}/git/refs/heads/$BRANCH_NAME -X DELETE || echo "⚠️  브랜치 삭제 실패 또는 이미 삭제됨: $BRANCH_NAME"
-


### PR DESCRIPTION
### 💡 To Reviewers
- github의 관련이슈는 기본 브랜치(현재는 main)에만 PR이 병합될 때 닫힙니다. 이를 dev 브랜치에 병합시에도 삭제되게 하여 이슈 목록을 깔끔하게 유지합니다.
- 소스 브랜치 또한 병합될 시 삭제하여 브랜치 목록을 깔끔하게 유지합니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- PR이 dev 브랜치에 병합될 때 이슈 번호를 인식하여 자동으로 닫히게 하는 워크플로우 파일 생성

### 🤔 추후 작업 예정
- github 세팅 오류가 나면 조치 예정

### 📸 작업 결과 (스크린샷)
- .

### 🔗 관련 이슈
- close #6 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated "PR merge cleanup" workflow: when a pull request is merged into main or dev it closes linked issues referenced with common keywords (e.g., close, fixes, resolves), attempts to delete the source branch, reports per-issue success/failure counts and a summary, and tolerates branch deletion failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->