### PR TITLE
Fix-246 : 버그 수정

### DIFF
--- a/src/app/groups/[id]/admin/layout.tsx
+++ b/src/app/groups/[id]/admin/layout.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { useClubAccessGuard } from "@/hooks/useClubAccessGuard";
+
+export default function GroupAdminLayout({ children }: { children: React.ReactNode }) {
+  const params = useParams();
+  const clubId = Number(params.id);
+
+  const access = useClubAccessGuard({
+    clubId,
+    require: "staff",
+  });
+
+  if (access.isCheckingAccess) {
+    return <div className="w-full px-6 py-10 body_1_2 text-Gray-5">불러오는 중...</div>;
+  }
+
+  if (access.isUnauthorized) {
+    return null;
+  }
+
+  if (access.isError) {
+    return <div className="w-full px-6 py-10 body_1_2 text-Red">모임 정보를 불러오지 못했습니다.</div>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/groups/[id]/bookcase/[bookId]/meeting/layout.tsx
+++ b/src/app/groups/[id]/bookcase/[bookId]/meeting/layout.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { useClubAccessGuard } from "@/hooks/useClubAccessGuard";
+
+export default function MeetingAdminAccessLayout({ children }: { children: React.ReactNode }) {
+  const params = useParams();
+  const clubId = Number(params.id);
+
+  const access = useClubAccessGuard({
+    clubId,
+    require: "member",
+  });
+
+  if (access.isCheckingAccess) {
+    return <div className="w-full px-6 py-10 body_1_2 text-Gray-5">불러오는 중...</div>;
+  }
+
+  if (access.isUnauthorized) {
+    return null;
+  }
+
+  if (access.isError) {
+    return <div className="w-full px-6 py-10 body_1_2 text-Red">모임 정보를 불러오지 못했습니다.</div>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/groups/[id]/bookcase/[bookId]/meeting/page.tsx
+++ b/src/app/groups/[id]/bookcase/[bookId]/meeting/page.tsx
@@ -235,6 +235,27 @@ export default function MeetingPage() {
   const canSelectCurrentTeamTopic =
     isStaff || (selectedTeamId !== null && myTeamId === selectedTeamId);
 
+  const presentationSubscribeTeamId = isStaff ? selectedTeamId : myTeamId;
+
+  useEffect(() => {
+    console.log("[meeting page] selectedTeam state changed", {
+      selectedTeamId,
+      selectedTeamName: selectedTeam?.teamName ?? null,
+      myTeamId,
+      canSelectCurrentTeamTopic,
+      isConnected,
+      presentationSubscribeTeamId,
+      pendingKeys: [...pendingPresentationKeys],
+    });
+  }, [
+    selectedTeamId,
+    selectedTeam?.teamName,
+    myTeamId,
+    canSelectCurrentTeamTopic,
+    presentationSubscribeTeamId,
+    pendingPresentationKeys,
+  ]);
+
   const chatSelectableTeams = useMemo<ChatTeam[]>(() => {
     const mapped = teams.map((team) => ({
       teamId: String(team.teamId),
@@ -255,7 +276,7 @@ export default function MeetingPage() {
   } = useMeetingRealtime({
     clubId,
     meetingId,
-    presentationTeamId: selectedTeamId,
+    presentationTeamId: presentationSubscribeTeamId ?? null,
     chatTeamId: selectedChatTeamId,
     isChatOpen: isChatModalOpen,
     isStaff,
@@ -289,6 +310,14 @@ export default function MeetingPage() {
   const handleSelectTeam = (teamName: string) => {
     const matched = teams.find((team) => team.teamName === teamName);
     if (!matched) return;
+
+    console.log("[meeting page] handleSelectTeam", {
+      clickedTeamName: teamName,
+      nextTeamId: matched.teamId,
+      prevSelectedTeamId: selectedTeamId,
+      myTeamId,
+      presentationSubscribeTeamId,
+    });
 
     setSelectedTeamId(matched.teamId);
 
@@ -393,6 +422,20 @@ export default function MeetingPage() {
   const handleTogglePresentation = (topicId: number, currentSelected: boolean) => {
     if (selectedTeamId === null) return;
 
+    const key = makePresentationPendingKey(selectedTeamId, topicId);
+
+    console.log("[meeting page] toggle attempt", {
+      selectedTeamId,
+      myTeamId,
+      topicId,
+      currentSelected,
+      canSelectCurrentTeamTopic,
+      isConnected,
+      presentationSubscribeTeamId,
+      isPending: pendingPresentationKeys.has(key),
+      pendingKeys: [...pendingPresentationKeys],
+    });
+
     if (!canSelectCurrentTeamTopic) {
       toast.error("현재 조의 발제만 선택할 수 있습니다.");
       return;
@@ -402,8 +445,6 @@ export default function MeetingPage() {
       toast.error("실시간 연결이 아직 되지 않았습니다.");
       return;
     }
-
-    const key = makePresentationPendingKey(selectedTeamId, topicId);
 
     if (pendingPresentationKeys.has(key)) {
       return;

--- a/src/app/groups/[id]/bookcase/[bookId]/meeting/page.tsx
+++ b/src/app/groups/[id]/bookcase/[bookId]/meeting/page.tsx
@@ -237,25 +237,6 @@ export default function MeetingPage() {
 
   const presentationSubscribeTeamId = isStaff ? selectedTeamId : myTeamId;
 
-  useEffect(() => {
-    console.log("[meeting page] selectedTeam state changed", {
-      selectedTeamId,
-      selectedTeamName: selectedTeam?.teamName ?? null,
-      myTeamId,
-      canSelectCurrentTeamTopic,
-      isConnected,
-      presentationSubscribeTeamId,
-      pendingKeys: [...pendingPresentationKeys],
-    });
-  }, [
-    selectedTeamId,
-    selectedTeam?.teamName,
-    myTeamId,
-    canSelectCurrentTeamTopic,
-    presentationSubscribeTeamId,
-    pendingPresentationKeys,
-  ]);
-
   const chatSelectableTeams = useMemo<ChatTeam[]>(() => {
     const mapped = teams.map((team) => ({
       teamId: String(team.teamId),
@@ -423,18 +404,6 @@ export default function MeetingPage() {
     if (selectedTeamId === null) return;
 
     const key = makePresentationPendingKey(selectedTeamId, topicId);
-
-    console.log("[meeting page] toggle attempt", {
-      selectedTeamId,
-      myTeamId,
-      topicId,
-      currentSelected,
-      canSelectCurrentTeamTopic,
-      isConnected,
-      presentationSubscribeTeamId,
-      isPending: pendingPresentationKeys.has(key),
-      pendingKeys: [...pendingPresentationKeys],
-    });
 
     if (!canSelectCurrentTeamTopic) {
       toast.error("현재 조의 발제만 선택할 수 있습니다.");

--- a/src/app/groups/[id]/layout.tsx
+++ b/src/app/groups/[id]/layout.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Image from "next/image";
 
 import { useClubhomeQueries } from "@/hooks/queries/useClubhomeQueries";
+import { useClubAccessGuard } from "@/hooks/useClubAccessGuard";
 
 type TabType = "home" | "notice" | "bookcase";
 
@@ -21,10 +22,41 @@ export default function GroupDetailLayout({ children }: { children: React.ReactN
     return pathname?.includes("/admin/");
   }, [pathname]);
 
+  const requiresMemberAccess = useMemo(() => {
+    if (!pathname) return false;
+    if (skipLayout) return false;
+    return pathname.includes("/notice") || pathname.includes("/bookcase");
+  }, [pathname, skipLayout]);
+
   const safeClubId = skipLayout ? NaN : groupIdNum;
   const { homeQuery } = useClubhomeQueries(safeClubId);
+  const access = useClubAccessGuard({
+    clubId: groupIdNum,
+    require: "member",
+    enabled: requiresMemberAccess,
+  });
 
   if (skipLayout) return <>{children}</>;
+
+  if (requiresMemberAccess && access.isCheckingAccess) {
+    return (
+      <div className="w-full px-6 py-10 body_1_2 text-Gray-5">
+        불러오는 중...
+      </div>
+    );
+  }
+
+  if (requiresMemberAccess && access.isUnauthorized) {
+    return null;
+  }
+
+  if (requiresMemberAccess && access.isError) {
+    return (
+      <div className="w-full px-6 py-10 body_1_2 text-Red">
+        모임 정보를 불러오지 못했습니다.
+      </div>
+    );
+  }
 
   const groupName = homeQuery.data?.name ?? "";
 

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -1,7 +1,6 @@
 ﻿"use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import { useRouter, useParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
@@ -11,6 +10,7 @@ import ButtonWithoutImg from "@/components/base-ui/button_without_img";
 import GroupAdminMenu from "@/components/base-ui/Group/group_admin_menu";
 
 import { useClubhomeQueries } from "@/hooks/queries/useClubhomeQueries";
+import { isClubMember } from "@/hooks/useClubAccessGuard";
 
 const DEFAULT_CLUB_IMG = "/ClubDefaultImg.svg";
 
@@ -64,6 +64,7 @@ export default function GroupDetailPage() {
   
 
   const isAdmin = me.staff === true;
+  const canAccessMemberOnlyPage = isClubMember(me);
   
   const noticeText = latestNotice?.title ?? "공지사항이 없습니다.";
   const hasNotice = Boolean(latestNotice?.id);
@@ -98,10 +99,16 @@ export default function GroupDetailPage() {
   }, [home.links]);
 
   const onClickJoin = () => {
+    if (!canAccessMemberOnlyPage) {
+      toast.error("회원만 접근이 가능합니다.");
+      return;
+    }
+
     if (!joinUrl) {
       toast.error("다음 정기모임이 없습니다.");
       return;
     }
+
     router.push(joinUrl);
   };
 
@@ -113,6 +120,10 @@ export default function GroupDetailPage() {
           role="button"
           tabIndex={0}
           onClick={() => {
+            if (!canAccessMemberOnlyPage) {
+              toast.error("회원만 접근이 가능합니다.");
+              return;
+            }
             if (!hasNotice) {
               toast.error("공지사항이 없습니다.");
               return;
@@ -122,6 +133,10 @@ export default function GroupDetailPage() {
           onKeyDown={(e) => {
             if (e.key !== "Enter" && e.key !== " ") return;
             e.preventDefault();
+            if (!canAccessMemberOnlyPage) {
+              toast.error("회원만 접근이 가능합니다.");
+              return;
+            }
             if (!hasNotice) {
               toast.error("공지사항이 없습니다.");
               return;

--- a/src/hooks/realtime/useMeetingRealtime.ts
+++ b/src/hooks/realtime/useMeetingRealtime.ts
@@ -77,6 +77,17 @@ export function useMeetingRealtime({
       onPresentationEvent,
       onRealtimeResynced,
     };
+
+    console.log("[meeting realtime] latestRef updated", {
+      clubId,
+      meetingId,
+      presentationTeamId,
+      chatTeamId,
+      isChatOpen,
+      isStaff,
+      myTeamId,
+      enabled,
+    });
   }, [
     clubId,
     meetingId,
@@ -87,9 +98,16 @@ export function useMeetingRealtime({
     myTeamId,
     onPresentationEvent,
     onRealtimeResynced,
+    enabled,
   ]);
 
   const cleanupSubscriptions = useCallback(() => {
+    console.log("[meeting realtime] cleanupSubscriptions", {
+      hasPresentationSub: !!subscriptionsRef.current.presentation,
+      hasChatSub: !!subscriptionsRef.current.chat,
+      hasErrorSub: !!subscriptionsRef.current.error,
+    });
+
     subscriptionsRef.current.presentation?.unsubscribe();
     subscriptionsRef.current.chat?.unsubscribe();
     subscriptionsRef.current.error?.unsubscribe();
@@ -98,6 +116,8 @@ export function useMeetingRealtime({
 
   const invalidateRealtimeQueries = useCallback(async () => {
     const current = latestRef.current;
+
+    console.log("[meeting realtime] invalidateRealtimeQueries", current);
 
     if (current.presentationTeamId) {
       await queryClient.invalidateQueries({
@@ -134,11 +154,22 @@ export function useMeetingRealtime({
 
   const resubscribe = useCallback(() => {
     const client = clientRef.current;
+
+    console.log("[meeting realtime] resubscribe called", {
+      clientExists: !!client,
+      clientConnected: !!client?.connected,
+      latest: latestRef.current,
+    });
+
     if (!client || !client.connected) return;
 
     cleanupSubscriptions();
 
     const current = latestRef.current;
+
+    console.log("[meeting realtime] subscribe error queue", {
+      destination: meetingRealtimeDestinations.userErrorQueue,
+    });
 
     subscriptionsRef.current.error = client.subscribe(
       meetingRealtimeDestinations.userErrorQueue,
@@ -158,19 +189,36 @@ export function useMeetingRealtime({
       }
     );
 
-    if (current.presentationTeamId) {
-      subscriptionsRef.current.presentation = client.subscribe(
-        meetingRealtimeDestinations.subscribePresentation(
-          current.clubId,
-          current.meetingId,
-          current.presentationTeamId
-        ),
-        (message) => {
-          const event = JSON.parse(message.body) as MeetingPresentationEvent;
-          applyPresentationEventToTopicsCache(queryClient, event);
-          latestRef.current.onPresentationEvent?.(event);
-        }
+    const canSubscribePresentation =
+      current.presentationTeamId !== null &&
+      (current.isStaff || current.presentationTeamId === current.myTeamId);
+
+    if (canSubscribePresentation && current.presentationTeamId) {
+      const destination = meetingRealtimeDestinations.subscribePresentation(
+        current.clubId,
+        current.meetingId,
+        current.presentationTeamId
       );
+
+      console.log("[meeting realtime] subscribe presentation", {
+        destination,
+        teamId: current.presentationTeamId,
+      });
+
+      subscriptionsRef.current.presentation = client.subscribe(destination, (message) => {
+        const event = JSON.parse(message.body) as MeetingPresentationEvent;
+
+        console.log("[meeting realtime] presentation event received", event);
+
+        applyPresentationEventToTopicsCache(queryClient, event);
+        latestRef.current.onPresentationEvent?.(event);
+      });
+    } else {
+      console.log("[meeting realtime] skip presentation subscribe", {
+        presentationTeamId: current.presentationTeamId,
+        isStaff: current.isStaff,
+        myTeamId: current.myTeamId,
+      });
     }
 
     const canSubscribeChat =
@@ -179,46 +227,81 @@ export function useMeetingRealtime({
       (current.isStaff || current.chatTeamId === current.myTeamId);
 
     if (canSubscribeChat && current.chatTeamId) {
-      subscriptionsRef.current.chat = client.subscribe(
-        meetingRealtimeDestinations.subscribeChatMessages(
-          current.clubId,
-          current.meetingId,
-          current.chatTeamId
-        ),
-        (message) => {
-          const event = JSON.parse(message.body) as MeetingChatMessageEvent;
-          appendChatMessageToChatsCache(queryClient, event);
-        }
+      const destination = meetingRealtimeDestinations.subscribeChatMessages(
+        current.clubId,
+        current.meetingId,
+        current.chatTeamId
       );
+
+      console.log("[meeting realtime] subscribe chat", {
+        destination,
+        teamId: current.chatTeamId,
+      });
+
+      subscriptionsRef.current.chat = client.subscribe(destination, (message) => {
+        const event = JSON.parse(message.body) as MeetingChatMessageEvent;
+
+        console.log("[meeting realtime] chat event received", event);
+
+        appendChatMessageToChatsCache(queryClient, event);
+      });
+    } else {
+      console.log("[meeting realtime] skip chat subscribe", {
+        isChatOpen: current.isChatOpen,
+        chatTeamId: current.chatTeamId,
+        isStaff: current.isStaff,
+        myTeamId: current.myTeamId,
+      });
     }
   }, [cleanupSubscriptions, queryClient]);
 
   useEffect(() => {
+    console.log("[meeting realtime] create client effect", {
+      enabled,
+      clubId,
+      meetingId,
+    });
+
     if (!enabled) return;
     if (!Number.isFinite(clubId) || !Number.isFinite(meetingId)) return;
 
     const client = createMeetingStompClient({
       onConnect: async () => {
+        console.log("[meeting realtime] onConnect", {
+          clubId,
+          meetingId,
+          latest: latestRef.current,
+        });
+
         setIsConnected(true);
         resubscribe();
         await invalidateRealtimeQueries();
         latestRef.current.onRealtimeResynced?.();
       },
-      onStompError: () => {
+      onStompError: (frame) => {
+        console.error("[meeting realtime] onStompError", {
+          headers: frame.headers,
+          body: frame.body,
+        });
         setIsConnected(false);
       },
       onWebSocketClose: () => {
+        console.warn("[meeting realtime] onWebSocketClose");
         setIsConnected(false);
       },
-      onWebSocketError: () => {
+      onWebSocketError: (event) => {
+        console.error("[meeting realtime] onWebSocketError", event);
         setIsConnected(false);
       },
     });
 
     clientRef.current = client;
+
+    console.log("[meeting realtime] client.activate()");
     client.activate();
 
     return () => {
+      console.log("[meeting realtime] cleanup effect - deactivate client");
       setIsConnected(false);
       cleanupSubscriptions();
       void client.deactivate();
@@ -227,6 +310,15 @@ export function useMeetingRealtime({
   }, [clubId, meetingId, enabled, cleanupSubscriptions, resubscribe, invalidateRealtimeQueries]);
 
   useEffect(() => {
+    console.log("[meeting realtime] dependency changed", {
+      presentationTeamId,
+      chatTeamId,
+      isChatOpen,
+      isStaff,
+      myTeamId,
+      connected: clientRef.current?.connected ?? false,
+    });
+
     if (!clientRef.current?.connected) return;
     resubscribe();
   }, [presentationTeamId, chatTeamId, isChatOpen, isStaff, myTeamId, resubscribe]);
@@ -235,6 +327,14 @@ export function useMeetingRealtime({
     (teamId: number, rawContent: string) => {
       const client = clientRef.current;
       const content = rawContent.trim();
+
+      console.log("[meeting realtime] publishChatMessage", {
+        teamId,
+        rawContent,
+        connected: !!client?.connected,
+        isStaff,
+        myTeamId,
+      });
 
       if (!client || !client.connected) {
         throw new Error("웹소켓이 아직 연결되지 않았습니다.");
@@ -270,6 +370,13 @@ export function useMeetingRealtime({
   const publishPresentation = useCallback(
     (teamId: number, topicId: number, isSelected: boolean) => {
       const client = clientRef.current;
+
+      console.log("[meeting realtime] publishPresentation", {
+        teamId,
+        topicId,
+        isSelected,
+        connected: !!client?.connected,
+      });
 
       if (!client || !client.connected) {
         throw new Error("웹소켓이 아직 연결되지 않았습니다.");

--- a/src/hooks/realtime/useMeetingRealtime.ts
+++ b/src/hooks/realtime/useMeetingRealtime.ts
@@ -77,17 +77,6 @@ export function useMeetingRealtime({
       onPresentationEvent,
       onRealtimeResynced,
     };
-
-    console.log("[meeting realtime] latestRef updated", {
-      clubId,
-      meetingId,
-      presentationTeamId,
-      chatTeamId,
-      isChatOpen,
-      isStaff,
-      myTeamId,
-      enabled,
-    });
   }, [
     clubId,
     meetingId,
@@ -102,11 +91,6 @@ export function useMeetingRealtime({
   ]);
 
   const cleanupSubscriptions = useCallback(() => {
-    console.log("[meeting realtime] cleanupSubscriptions", {
-      hasPresentationSub: !!subscriptionsRef.current.presentation,
-      hasChatSub: !!subscriptionsRef.current.chat,
-      hasErrorSub: !!subscriptionsRef.current.error,
-    });
 
     subscriptionsRef.current.presentation?.unsubscribe();
     subscriptionsRef.current.chat?.unsubscribe();
@@ -155,21 +139,11 @@ export function useMeetingRealtime({
   const resubscribe = useCallback(() => {
     const client = clientRef.current;
 
-    console.log("[meeting realtime] resubscribe called", {
-      clientExists: !!client,
-      clientConnected: !!client?.connected,
-      latest: latestRef.current,
-    });
-
     if (!client || !client.connected) return;
 
     cleanupSubscriptions();
 
     const current = latestRef.current;
-
-    console.log("[meeting realtime] subscribe error queue", {
-      destination: meetingRealtimeDestinations.userErrorQueue,
-    });
 
     subscriptionsRef.current.error = client.subscribe(
       meetingRealtimeDestinations.userErrorQueue,
@@ -180,12 +154,6 @@ export function useMeetingRealtime({
         } catch {
           parsed = null;
         }
-
-        console.error("[meeting realtime][error queue]", {
-          headers: message.headers,
-          body: message.body,
-          parsed,
-        });
       }
     );
 
@@ -200,25 +168,14 @@ export function useMeetingRealtime({
         current.presentationTeamId
       );
 
-      console.log("[meeting realtime] subscribe presentation", {
-        destination,
-        teamId: current.presentationTeamId,
-      });
-
       subscriptionsRef.current.presentation = client.subscribe(destination, (message) => {
         const event = JSON.parse(message.body) as MeetingPresentationEvent;
 
-        console.log("[meeting realtime] presentation event received", event);
 
         applyPresentationEventToTopicsCache(queryClient, event);
         latestRef.current.onPresentationEvent?.(event);
       });
     } else {
-      console.log("[meeting realtime] skip presentation subscribe", {
-        presentationTeamId: current.presentationTeamId,
-        isStaff: current.isStaff,
-        myTeamId: current.myTeamId,
-      });
     }
 
     const canSubscribeChat =
@@ -233,45 +190,24 @@ export function useMeetingRealtime({
         current.chatTeamId
       );
 
-      console.log("[meeting realtime] subscribe chat", {
-        destination,
-        teamId: current.chatTeamId,
-      });
 
       subscriptionsRef.current.chat = client.subscribe(destination, (message) => {
         const event = JSON.parse(message.body) as MeetingChatMessageEvent;
 
-        console.log("[meeting realtime] chat event received", event);
 
         appendChatMessageToChatsCache(queryClient, event);
       });
     } else {
-      console.log("[meeting realtime] skip chat subscribe", {
-        isChatOpen: current.isChatOpen,
-        chatTeamId: current.chatTeamId,
-        isStaff: current.isStaff,
-        myTeamId: current.myTeamId,
-      });
     }
   }, [cleanupSubscriptions, queryClient]);
 
   useEffect(() => {
-    console.log("[meeting realtime] create client effect", {
-      enabled,
-      clubId,
-      meetingId,
-    });
 
     if (!enabled) return;
     if (!Number.isFinite(clubId) || !Number.isFinite(meetingId)) return;
 
     const client = createMeetingStompClient({
       onConnect: async () => {
-        console.log("[meeting realtime] onConnect", {
-          clubId,
-          meetingId,
-          latest: latestRef.current,
-        });
 
         setIsConnected(true);
         resubscribe();
@@ -297,11 +233,9 @@ export function useMeetingRealtime({
 
     clientRef.current = client;
 
-    console.log("[meeting realtime] client.activate()");
     client.activate();
 
     return () => {
-      console.log("[meeting realtime] cleanup effect - deactivate client");
       setIsConnected(false);
       cleanupSubscriptions();
       void client.deactivate();
@@ -310,14 +244,7 @@ export function useMeetingRealtime({
   }, [clubId, meetingId, enabled, cleanupSubscriptions, resubscribe, invalidateRealtimeQueries]);
 
   useEffect(() => {
-    console.log("[meeting realtime] dependency changed", {
-      presentationTeamId,
-      chatTeamId,
-      isChatOpen,
-      isStaff,
-      myTeamId,
-      connected: clientRef.current?.connected ?? false,
-    });
+
 
     if (!clientRef.current?.connected) return;
     resubscribe();
@@ -370,13 +297,6 @@ export function useMeetingRealtime({
   const publishPresentation = useCallback(
     (teamId: number, topicId: number, isSelected: boolean) => {
       const client = clientRef.current;
-
-      console.log("[meeting realtime] publishPresentation", {
-        teamId,
-        topicId,
-        isSelected,
-        connected: !!client?.connected,
-      });
 
       if (!client || !client.connected) {
         throw new Error("웹소켓이 아직 연결되지 않았습니다.");

--- a/src/hooks/useClubAccessGuard.ts
+++ b/src/hooks/useClubAccessGuard.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+
+import { useClubMeQuery } from "@/hooks/queries/useClubhomeQueries";
+import type { MyClubStatus, MyClubStatusResponseResult } from "@/types/groups/grouphome";
+
+const MEMBER_STATUSES = new Set<MyClubStatus>(["MEMBER", "STAFF", "OWNER"]);
+const STAFF_STATUSES = new Set<MyClubStatus>(["STAFF", "OWNER"]);
+
+type ClubAccessLevel = "member" | "staff";
+
+type ClubAccessGuardOptions = {
+  clubId: number;
+  require?: ClubAccessLevel;
+  fallbackPath?: string;
+  toastMessage?: string;
+  enabled?: boolean;
+};
+
+type ClubAccessLike = Pick<MyClubStatusResponseResult, "myStatus" | "active" | "staff">;
+
+function getErrorCode(error: unknown) {
+  if (!error || typeof error !== "object") return "";
+  return "code" in error && typeof error.code === "string" ? error.code : "";
+}
+
+export function isClubMember(access?: ClubAccessLike | null) {
+  if (!access) return false;
+  return access.active === true && MEMBER_STATUSES.has(access.myStatus);
+}
+
+export function isClubStaff(access?: ClubAccessLike | null) {
+  if (!access) return false;
+  if (access.staff === true) return true;
+  return STAFF_STATUSES.has(access.myStatus);
+}
+
+export function useClubAccessGuard({
+  clubId,
+  require = "member",
+  fallbackPath,
+  toastMessage,
+  enabled = true,
+}: ClubAccessGuardOptions) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const handledRef = useRef(false);
+
+  const meQuery = useClubMeQuery(clubId);
+  const meData = meQuery.data;
+
+  const isMember = useMemo(() => isClubMember(meData), [meData]);
+  const isStaff = useMemo(() => isClubStaff(meData), [meData]);
+  const isAllowed = require === "staff" ? isStaff : isMember;
+
+  const errorCode = getErrorCode(meQuery.error);
+  const isPermissionError = errorCode === "COMMON401" || errorCode === "COMMON403";
+
+  const isCheckingAccess = enabled && meQuery.isLoading;
+  const isUnauthorized =
+    enabled &&
+    !meQuery.isLoading &&
+    ((meQuery.isSuccess && !isAllowed) || (isPermissionError && !isAllowed));
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!Number.isFinite(clubId) || clubId <= 0) return;
+    if (!isUnauthorized || handledRef.current) return;
+
+    handledRef.current = true;
+
+    toast.error(
+      toastMessage ??
+        (require === "staff" ? "운영진만 접근이 가능합니다." : "회원만 접근이 가능합니다."),
+      { id: `club-access-${require}-${clubId}-${pathname}` }
+    );
+
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+      return;
+    }
+
+    router.replace(fallbackPath ?? `/groups/${clubId}`);
+  }, [clubId, enabled, fallbackPath, isUnauthorized, pathname, require, router, toastMessage]);
+
+  return {
+    ...meQuery,
+    meData,
+    isMember,
+    isStaff,
+    isAllowed,
+    isCheckingAccess,
+    isUnauthorized,
+  };
+}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 일반 회원이 다른 조(A조 등) 조회 후 자신의 조로 돌아왔을 때, 발제 선택 기능이 즉시 동작하지 않던 문제를 수정했습니다.
- 원인은 일반 회원도 선택된 조 기준으로 presentation websocket을 구독하면서, 권한이 없는 조 구독 시 STOMP ERROR로 연결이 종료되던 것이었습니다.
- 이를 일반 회원은 자신의 조만 presentation websocket을 구독하도록 수정해, 다른 조 조회 후에도 기존 연결이 끊기지 않도록 변경했습니다.

## 🛠️ 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )
## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added member-level access control for group admin pages, meeting sections, and notices
  * Enhanced real-time chat and presentation subscription with team-specific access permissions

* **Bug Fixes**
  * Improved unauthorized access error handling and user feedback
  * Enhanced WebSocket and real-time connection error diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->