### PR TITLE
feat: 사용자 추천 프로필 클릭 시 상대방 프로필로 이동 구현

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -14,6 +14,7 @@ import { useHomeInteractions } from "@/hooks/useHomeInteractions";
 
 
 export default function HomePage() {
+  const router = useRouter();
   const { isLoggedIn, openLoginModal } = useAuthStore();
   const { handleToggleFollow } = useHomeInteractions();
 
@@ -51,6 +52,7 @@ export default function HomePage() {
                 users={recommendedUsers}
                 isError={isErrorMembers}
                 isLoading={isLoadingMembers}
+                onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
                 onSubscribeClick={handleToggleFollow}
               />
             </div>

--- a/src/app/(main)/stories/page.tsx
+++ b/src/app/(main)/stories/page.tsx
@@ -178,6 +178,7 @@ export default function StoriesPage() {
             <ListSubscribeLarge
               height="h-[380px]"
               users={recommendedMembers}
+              onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
               onSubscribeClick={(nickname, isFollowing) => handleToggleFollow(nickname, isFollowing)}
             />
           )

--- a/src/components/base-ui/home/Recommendation/HomeRecommendationSection.tsx
+++ b/src/components/base-ui/home/Recommendation/HomeRecommendationSection.tsx
@@ -7,6 +7,7 @@ interface HomeRecommendationSectionProps {
   users: RecommendedMember[];
   isError: boolean;
   isLoading?: boolean;
+  onProfileClick?: (nickname: string) => void;
   onSubscribeClick: (nickname: string, isFollowing: boolean) => void;
 }
 
@@ -16,6 +17,7 @@ export default function HomeRecommendationSection({
   users,
   isError,
   isLoading,
+  onProfileClick,
   onSubscribeClick,
 }: HomeRecommendationSectionProps) {
   if (isLoading) {
@@ -45,6 +47,7 @@ export default function HomeRecommendationSection({
                 name={u.nickname}
                 profileSrc={u.profileImageUrl}
                 isFollowing={u.isFollowing}
+                onProfileClick={() => onProfileClick?.(u.nickname)}
                 onSubscribeClick={() => onSubscribeClick(u.nickname, u.isFollowing)}
               />
             ))
@@ -58,6 +61,7 @@ export default function HomeRecommendationSection({
           height="h-[424px] d:h-[380px]"
           users={users}
           isError={isError}
+          onProfileClick={onProfileClick}
           onSubscribeClick={onSubscribeClick}
         />
       </div>

--- a/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
@@ -6,6 +6,7 @@ type ListSubscribeElementProps = {
   subscribingCount?: number; // 구독중
   subscribersCount?: number; // 구독자
   profileSrc?: string; // 기본: "/profile2.svg" (public)
+  onProfileClick?: () => void;
   onSubscribeClick?: () => void;
   buttonText?: string; // 기본: "구독"
   isFollowing?: boolean;
@@ -16,12 +17,16 @@ export default function ListSubscribeElement({
   subscribingCount,
   subscribersCount,
   profileSrc = '/profile2.svg',
+  onProfileClick,
   onSubscribeClick,
   buttonText = '구독',
   isFollowing = false,
 }: ListSubscribeElementProps) {
   return (
-    <div className="flex w-full t:w-[296px] min-h-[60px] t:h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white">
+    <div 
+      className="flex w-full t:w-[296px] min-h-[60px] t:h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white cursor-pointer hover:bg-stone-100 transition-colors group"
+      onClick={onProfileClick}
+    >
       <div className="w-[24px] h-[24px] t:w-[32px] t:h-[32px] rounded-full overflow-hidden shrink-0 relative self-center">
         <Image
           src={isValidUrl(profileSrc) ? profileSrc : '/profile2.svg'}
@@ -36,7 +41,7 @@ export default function ListSubscribeElement({
       {/* 오른쪽 모바일(세로), 태블릿부터(가로) */}
       <div className="flex flex-col t:flex-row flex-1 min-w-0 gap-1 t:gap-[8px] t:items-center">
         <div className="flex flex-col min-w-0 flex-1">
-          <p className="text-Gray-7 body_2_1 t:body_1 truncate">{name}</p>
+          <p className="text-Gray-7 body_2_1 t:body_1 truncate group-hover:underline">{name}</p>
           {subscribingCount !== undefined && subscribersCount !== undefined && (
             <p className="body_2_3 t:text-Gray-3 hidden t:block">
               구독중 {subscribingCount} 구독자 {subscribersCount}
@@ -47,7 +52,7 @@ export default function ListSubscribeElement({
         {/* Button */}
         <button
           type="button"
-          onClick={onSubscribeClick}
+          onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
           className={`hidden t:flex px-[10px] t:px-[17px] py-[6px] t:py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[11px] t:text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors ${isFollowing
             ? "bg-Subbrown-4 text-primary-3"
             : "bg-primary-2 text-white"
@@ -58,7 +63,7 @@ export default function ListSubscribeElement({
         {/* 모바일 버튼 */}
         <button
           type="button"
-          onClick={onSubscribeClick}
+          onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
           className={`flex t:hidden w-full px-[17px] py-[6px] justify-center items-center rounded-[10px] text-[11px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap transition-colors ${isFollowing
             ? "bg-Subbrown-4 text-primary-3"
             : "bg-primary-2 text-white"

--- a/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
@@ -23,9 +23,11 @@ export default function ListSubscribeElement({
   isFollowing = false,
 }: ListSubscribeElementProps) {
   return (
-    <div 
-      className="flex w-full t:w-[296px] min-h-[60px] t:h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white cursor-pointer hover:bg-stone-100 transition-colors group"
+    <div
+      className={`flex w-full t:w-[296px] min-h-[60px] t:h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white transition-colors group ${onProfileClick ? "cursor-pointer hover:bg-stone-100" : ""}`}
       onClick={onProfileClick}
+      role={onProfileClick ? "button" : undefined}
+      tabIndex={onProfileClick ? 0 : -1}
     >
       <div className="w-[24px] h-[24px] t:w-[32px] t:h-[32px] rounded-full overflow-hidden shrink-0 relative self-center">
         <Image

--- a/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
@@ -26,8 +26,10 @@ function ListSubscribeElementLarge({
 }: ListSubscribeElementLargeProps) {
   return (
     <div
-      className="flex w-[296px] h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white cursor-pointer hover:bg-stone-100 transition-colors group"
+      className={`flex w-[296px] h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white transition-colors group ${onProfileClick ? "cursor-pointer hover:bg-stone-100" : ""}`}
       onClick={onProfileClick}
+      role={onProfileClick ? "button" : undefined}
+      tabIndex={onProfileClick ? 0 : -1}
     >
       <div className="w-[32px] h-[32px] rounded-full overflow-hidden shrink-0 relative self-center">
         <Image
@@ -42,7 +44,7 @@ function ListSubscribeElementLarge({
 
       <div className="flex flex-row flex-1 min-w-0 gap-[8px] items-center">
         <div className="flex flex-col min-w-0 flex-1">
-          <p className="text-Gray-7 body_1 truncate ">{name}</p>
+          <p className={`text-Gray-7 body_1 truncate ${onProfileClick ? "group-hover:underline" : ""}`}>{name}</p>
           {subscribingCount !== undefined && subscribersCount !== undefined && (
             <p className="body_2_3 text-Gray-3">
               구독중 {subscribingCount} 구독자 {subscribersCount}

--- a/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
@@ -8,6 +8,7 @@ type ListSubscribeElementLargeProps = {
   subscribingCount?: number;
   subscribersCount?: number;
   profileSrc?: string;
+  onProfileClick?: () => void;
   onSubscribeClick?: () => void;
   buttonText?: string;
   isFollowing?: boolean;
@@ -18,12 +19,16 @@ function ListSubscribeElementLarge({
   subscribingCount,
   subscribersCount,
   profileSrc = '/profile2.svg',
+  onProfileClick,
   onSubscribeClick,
   buttonText = '구독',
   isFollowing = false,
 }: ListSubscribeElementLargeProps) {
   return (
-    <div className="flex w-[296px] h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white">
+    <div
+      className="flex w-[296px] h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white cursor-pointer hover:bg-stone-100 transition-colors group"
+      onClick={onProfileClick}
+    >
       <div className="w-[32px] h-[32px] rounded-full overflow-hidden shrink-0 relative self-center">
         <Image
           src={isValidUrl(profileSrc) ? profileSrc : '/profile2.svg'}
@@ -37,7 +42,7 @@ function ListSubscribeElementLarge({
 
       <div className="flex flex-row flex-1 min-w-0 gap-[8px] items-center">
         <div className="flex flex-col min-w-0 flex-1">
-          <p className="text-Gray-7 body_1 truncate">{name}</p>
+          <p className="text-Gray-7 body_1 truncate ">{name}</p>
           {subscribingCount !== undefined && subscribersCount !== undefined && (
             <p className="body_2_3 text-Gray-3">
               구독중 {subscribingCount} 구독자 {subscribersCount}
@@ -47,7 +52,7 @@ function ListSubscribeElementLarge({
 
         <button
           type="button"
-          onClick={onSubscribeClick}
+          onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
           className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors ${isFollowing
             ? "bg-Subbrown-4 text-primary-3"
             : "bg-primary-2 text-white"
@@ -71,6 +76,7 @@ type ListSubscribeLargeProps = {
   }>;
   isError?: boolean;
   isLoading?: boolean;
+  onProfileClick?: (nickname: string) => void;
   onSubscribeClick?: (nickname: string, isFollowing: boolean) => void;
 };
 
@@ -79,6 +85,7 @@ export default function ListSubscribeLarge({
   users = [],
   isError = false,
   isLoading = false,
+  onProfileClick,
   onSubscribeClick,
 }: ListSubscribeLargeProps) {
 
@@ -114,6 +121,7 @@ export default function ListSubscribeLarge({
               profileSrc={u.profileImageUrl}
               isFollowing={u.isFollowing}
               buttonText={u.isFollowing ? "구독중" : "구독"}
+              onProfileClick={() => onProfileClick?.(u.nickname)}
               onSubscribeClick={() => onSubscribeClick?.(u.nickname, u.isFollowing || false)}
             />
           ))}

--- a/src/components/base-ui/home/Story/HomeStoryList.tsx
+++ b/src/components/base-ui/home/Story/HomeStoryList.tsx
@@ -60,6 +60,7 @@ const HomeStoryList: React.FC<HomeStoryListProps> = ({
       users={recommendedUsers}
       isError={isErrorMembers}
       isLoading={isLoadingMembers}
+      onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
       onSubscribeClick={onToggleFollow}
     />
   ) : undefined;


### PR DESCRIPTION
📌 개요 (Summary)
홈 화면 및 스토리 페이지의 사용자 추천 목록에서 카드 클릭 시 해당 사용자의 프로필 페이지(/profile/[nickname])로 이동하는 기능을 구현했습니다.
관련 이슈: #260 

🛠️ 변경 사항 (Changes)
 새로운 기능 추가
사용자 추천 카드(컨테이너) 전체를 클릭 가능 영역으로 확대
클릭 시 해당 유저의 프로필로 이동하는 라우팅 로직 연결 (Home, Stories 페이지 공통 적용)
 코드 리팩토링
ListSubscribeElement, ListSubscribeLarge 컴포넌트의 인터페이스에 onProfileClick 추가하여 단일 구조 원칙 준수
구독 버튼 클릭 시 프로필 이동이 중복 발생하지 않도록 이벤트 버블링 방지(e.stopPropagation()) 처리
 기타 (설명: UX 개선)
마우스 오버 시 시각적 피드백을 위한 hover:bg-stone-100 및 cursor-pointer 스타일링 적용

📸 스크린샷 (Screenshots)



✅ 체크리스트 (Checklist)
상세 구현 노트
이벤트 분리: 카드의 어느 곳을 눌러도 프로필로 이동하지만, '구독' 버튼을 누를 때만은 프로필로 이동하지 않고 순수하게 구독 기능만 동작하도록 설계했습니다.
재사용성: 컴포넌트 내부에서 직접 useRouter를 사용하지 않고 부모로부터 핸들러를 주입받는 방식을 사용하여, 다른 페이지에서 추천 컴포넌트를 재사용할 때도 유연하게 대응할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now click on user cards in recommendations and subscription lists to navigate directly to their profiles. This interactive feature is available across the app, including home recommendations, story pages, and other user list sections, enabling seamless profile exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->