### PR TITLE
feat: 알림 조회 요청 관련 enable 옵션 추가 및 레드닷 로직 추가

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,7 +43,8 @@ export default function Header() {
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
   const notificationRef = useRef<HTMLDivElement>(null);
 
-  const { data: notifications } = useNotificationPreviewQuery(5, isLoggedIn);
+  const { data: notificationsData } = useNotificationPreviewQuery(5, isLoggedIn);
+  const notifications = isLoggedIn ? notificationsData : [];
   const hasUnread = notifications?.some((notif) => !notif.read) ?? false;
 
   useEffect(() => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { useState, useRef, useEffect } from "react";
 import SearchModal from "./SearchModal";
 
 import NotificationDropdown from "./NotificationDropdown";
+import { useNotificationPreviewQuery } from "@/hooks/queries/useNotificationQueries";
 import { useHeaderTitle } from "@/contexts/HeaderTitleContext";
 import { useAuthStore } from "@/store/useAuthStore";
 
@@ -41,6 +42,9 @@ export default function Header() {
 
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
   const notificationRef = useRef<HTMLDivElement>(null);
+
+  const { data: notifications } = useNotificationPreviewQuery(5, isLoggedIn);
+  const hasUnread = notifications?.some((notif) => !notif.read) ?? false;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -141,6 +145,9 @@ export default function Header() {
                   className="object-contain"
                   priority
                 />
+                {hasUnread && (
+                  <span className="absolute top-0 right-0 block w-1.5 h-1.5 bg-Red rounded-full border border-primary-1" />
+                )}
               </button>
               {isNotificationOpen && <NotificationDropdown />}
             </div>

--- a/src/components/layout/NotificationDropdown.tsx
+++ b/src/components/layout/NotificationDropdown.tsx
@@ -7,9 +7,11 @@ import { formatTimeAgo } from "@/utils/time";
 import { useReadNotificationMutation } from "@/hooks/mutations/useNotificationMutations";
 import { getNotificationText, getNotificationRedirectUrl } from "@/utils/notification";
 import { NotificationBasicInfo } from "@/types/notification";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export default function NotificationDropdown() {
-    const { data: notifications, isLoading } = useNotificationPreviewQuery(5);
+    const { isLoggedIn } = useAuthStore();
+    const { data: notifications, isLoading } = useNotificationPreviewQuery(5, isLoggedIn);
     const { mutate: readNotification } = useReadNotificationMutation();
     const router = useRouter();
 

--- a/src/components/layout/NotificationDropdown.tsx
+++ b/src/components/layout/NotificationDropdown.tsx
@@ -11,8 +11,8 @@ import { useAuthStore } from "@/store/useAuthStore";
 
 export default function NotificationDropdown() {
     const { isLoggedIn } = useAuthStore();
-    const { data: notifications, isLoading } = useNotificationPreviewQuery(5, isLoggedIn);
-    const { mutate: readNotification } = useReadNotificationMutation();
+    const { data: notificationsData, isLoading } = useNotificationPreviewQuery(5, isLoggedIn);
+    const notifications = isLoggedIn ? notificationsData : []; const { mutate: readNotification } = useReadNotificationMutation();
     const router = useRouter();
 
     const handleNotificationClick = (notification: NotificationBasicInfo) => {

--- a/src/hooks/queries/useNotificationQueries.ts
+++ b/src/hooks/queries/useNotificationQueries.ts
@@ -27,9 +27,10 @@ export const useInfiniteNotificationsQuery = () => {
     });
 };
 
-export const useNotificationPreviewQuery = (size?: number) => {
+export const useNotificationPreviewQuery = (size?: number, enabled?: boolean) => {
     return useQuery({
         queryKey: notificationKeys.preview(size),
         queryFn: () => notificationService.getNotificationPreview(size),
+        enabled,
     });
 };


### PR DESCRIPTION
주요 수정 사항
useNotificationPreviewQuery 훅 개선:
비로그인 상태에서 불필요한 알림 조회 요청이 발생하지 않도록 enabled 옵션을 추가했습니다.
Header.tsx 레드닷 로직 추가:
헤더에서 알림 데이터를 가져와 읽지 않은 알림(!notif.read)이 하나라도 존재할 경우 hasUnread 상태를 계산합니다.
hasUnread가 true일 때 알림 아이콘 우측 상단에 bg-Red 색상의 둥근 점을 렌더링하도록 UI를 추가했습니다.
데이터 동기화 및 성능 최적화:
TanStack Query의 캐시를 공유하므로, 알림 드롭다운을 열거나 알림을 읽었을 때(캐시 무효화) 헤더의 빨간 점도 즉각적으로 반응하여 사라지거나 나타납니다.
중복 네트워크 요청 없이 효율적으로 상태를 관리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The notification bell icon now displays a small red unread indicator badge when you have new notifications, making it easier to spot pending alerts at a glance.

* **Improvements**
  * Notification data fetching has been enhanced to respect your authentication state, ensuring notifications are appropriately loaded based on whether you are logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->