### PR TITLE
fix: 배너에 프로모션 리스트 수정

### DIFF
--- a/src/components/base-ui/News/NewsListBanner.tsx
+++ b/src/components/base-ui/News/NewsListBanner.tsx
@@ -13,9 +13,18 @@ export default function NewsListBanner() {
 
     const newsList = data?.pages.flatMap((page) => page.basicInfoList) || [];
 
+    // 'PROMOTION' 태그가 붙은 소식만 필터링 및 게시 종료 날짜 순 정렬 (최대 5개)
+    const promotionList = useMemo(() => {
+        return newsList
+            .filter((news) => news.carousel === "PROMOTION")
+            .sort((a, b) => new Date(b.publishEndAt).getTime() - new Date(a.publishEndAt).getTime())
+            .slice(0, 5);
+    }, [newsList]);
+
+    const slideCount = promotionList.length;
+
     // 5초 자동 슬라이드 로직
     useEffect(() => {
-        const slideCount = Math.min(newsList.length, 5);
         if (slideCount <= 1) return;
 
         const timer = setInterval(() => {
@@ -23,7 +32,7 @@ export default function NewsListBanner() {
         }, 5000);
 
         return () => clearInterval(timer);
-    }, [newsList.length]);
+    }, [slideCount]);
 
     if (isLoading) {
         return (
@@ -33,26 +42,31 @@ export default function NewsListBanner() {
         );
     }
 
-    if (isError || newsList.length === 0) {
+    if (isError) {
         return (
             <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1">
-                <div className="text-gray-400 text-lg font-medium">새로운 소식이 아직 없어요!</div>
-                <div className="text-gray-400 text-sm">준비 중인 소식을 기다려 주세요.</div>
+                <div className="text-gray-400 text-lg font-medium">소식을 불러오지 못했어요.</div>
             </div>
         );
     }
+
+    if (slideCount === 0) {
+        return (
+            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1">
+                <div className="text-gray-400 text-lg font-medium text-center px-4">책모의 소식에서 다양한 책 관련 행사를 알아보세요!</div>
+            </div>
+        );
+    }
+
+    const safeIndex = index % slideCount;
 
     const isValidSrc = (src: string) => {
         return src && src !== "string" && (src.startsWith("/") || src.startsWith("http://") || src.startsWith("https://"));
     };
 
-    // 최대 5개 노출
-    const slideCount = Math.min(newsList.length, 5);
-    const safeIndex = index % slideCount;
-
     return (
         <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] shadow-sm">
-            {newsList.slice(0, slideCount).map((news, i) => {
+            {promotionList.map((news, i) => {
                 const imageSrc = isValidSrc(news.thumbnailUrl) ? news.thumbnailUrl : "/news_sample.svg";
                 const isActive = i === safeIndex;
 
@@ -88,7 +102,7 @@ export default function NewsListBanner() {
 
             {/* 인디케이터 */}
             <div className="absolute top-[20px] left-[20px] t:top-[27px] t:left-[33px] flex gap-2 z-20">
-                {newsList.slice(0, slideCount).map((_, i) => {
+                {promotionList.map((_, i) => {
                     const active = i === safeIndex;
 
                     return (

--- a/src/components/base-ui/News/NewsListBanner.tsx
+++ b/src/components/base-ui/News/NewsListBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useInfiniteNewsQuery } from "@/hooks/queries/useNewsQueries";

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -5,6 +5,7 @@ export interface NewsBasicInfo {
     thumbnailUrl: string;
     carousel: "PROMOTION" | "GENERAL";
     publishStartAt: string;
+    publishEndAt: string;
 }
 
 export interface NewsListResponse {
@@ -23,4 +24,5 @@ export interface NewsDetail {
     carousel: "PROMOTION" | "GENERAL";
     imageUrls: string[];
     publishStartAt: string;
+    publishEndAt: string;
 }


### PR DESCRIPTION
## 📌 개요 (Summary)
- 변경 사항에 대한 간략한 요약을 적어주세요.
- 관련 이슈가 있다면 링크를 걸어주세요 (예: #300 )

## 🛠️ 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News banner now filters and displays only promotional items, limited to 5 most recent entries sorted by publish end date.

* **Bug Fixes**
  * Added explicit error UI display and improved empty-state handling.

* **Chores**
  * Added publication end-date field to news data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->