### PR TITLE
feat: 책 이야기 이어쓰기 및 임시 저장 api 연동

### DIFF
--- a/src/app/(main)/stories/[id]/edit/page.tsx
+++ b/src/app/(main)/stories/[id]/edit/page.tsx
@@ -168,7 +168,7 @@ export default function StoryEditPage() {
                   disabled={isPending}
                   className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-primary-1 disabled:opacity-50"
                 >
-                  임시저장
+                  {isPending ? "임시저장 중..." : "임시저장"}
                 </button>
                 <button
                   type="button"

--- a/src/app/(main)/stories/[id]/edit/page.tsx
+++ b/src/app/(main)/stories/[id]/edit/page.tsx
@@ -51,21 +51,33 @@ export default function StoryEditPage() {
     router.back();
   };
 
-  const handleSubmit = () => {
-    if (!description.trim()) {
+  const handleSubmit = (targetStatus?: "PUBLISHED" | "DRAFT") => {
+    // PUBLISHED일 경우 description 밸리데이션 처리
+    if (targetStatus === "PUBLISHED" && !description.trim()) {
       toast.error("내용을 입력해 주세요.");
       return;
     }
 
+    const payload = {
+      description,
+      ...(story ? { isbn: story.bookInfo.bookId, title: story.bookStoryTitle } : {}),
+      ...(targetStatus ? { status: targetStatus } : {})
+    };
+
     updateStory(
-      { bookStoryId, data: { description } },
+      { bookStoryId, data: payload },
       {
         onSuccess: () => {
-          toast.success("수정이 완료되었습니다.");
-          router.push(`/stories/${bookStoryId}`);
+          if (targetStatus === "DRAFT") {
+            toast.success("임시저장되었습니다.");
+            router.push("/profile/mypage");
+          } else {
+            toast.success(targetStatus === "PUBLISHED" && story?.status === "DRAFT" ? "발행이 완료되었습니다." : "수정이 완료되었습니다.");
+            router.push(`/stories/${bookStoryId}`);
+          }
         },
         onError: () => {
-          toast.error("수정에 실패했습니다. 다시 시도해 주세요.");
+          toast.error("저장에 실패했습니다. 다시 시도해 주세요.");
         },
       }
     );
@@ -148,21 +160,44 @@ export default function StoryEditPage() {
         {/* 하단 버튼 */}
         <div className="flex justify-center">
           <div className="flex w-full max-w-[1040px] justify-center t:justify-end gap-4 mt-6">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
-            >
-              취소
-            </button>
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={isPending}
-              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
-            >
-              {isPending ? "저장 중..." : "저장"}
-            </button>
+            {story.status === "DRAFT" ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => handleSubmit("DRAFT")}
+                  disabled={isPending}
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-primary-1 disabled:opacity-50"
+                >
+                  임시저장
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleSubmit("PUBLISHED")}
+                  disabled={isPending}
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
+                >
+                  {isPending ? "발행 중..." : "발행"}
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleSubmit()}
+                  disabled={isPending}
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
+                >
+                  {isPending ? "저장 중..." : "저장"}
+                </button>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/(main)/stories/new/page.tsx
+++ b/src/app/(main)/stories/new/page.tsx
@@ -159,7 +159,7 @@ function StoryNewContent() {
               disabled={createStoryMutation.isPending}
               className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-primary-1 disabled:opacity-50"
             >
-              임시저장
+              {createStoryMutation.isPending ? "임시저장 중..." : "임시저장"}
             </button>
             <button
               type="button"

--- a/src/app/(main)/stories/new/page.tsx
+++ b/src/app/(main)/stories/new/page.tsx
@@ -38,7 +38,7 @@ function StoryNewContent() {
     router.back();
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (status: "PUBLISHED" | "DRAFT" = "PUBLISHED") => {
     if (!selectedBook) {
       toast.error("책을 선택해 주세요.");
       return;
@@ -47,7 +47,7 @@ function StoryNewContent() {
       toast.error("제목을 입력해 주세요.");
       return;
     }
-    if (!detail.trim()) {
+    if (status === "PUBLISHED" && !detail.trim()) {
       toast.error("내용을 입력해 주세요.");
       return;
     }
@@ -56,14 +56,20 @@ function StoryNewContent() {
       isbn: selectedBook.isbn,
       title,
       description: detail,
+      status,
     }, {
       onSuccess: () => {
-        toast.success("스토리가 등록되었습니다!");
-        router.push("/stories");
+        if (status === "DRAFT") {
+          toast.success("임시저장되었습니다.");
+          router.push("/profile/mypage"); // 임시저장 시 마이페이지로 이동
+        } else {
+          toast.success("스토리가 등록되었습니다!");
+          router.push("/stories");
+        }
       },
       onError: (error) => {
         console.error("스토리 등록 실패:", error);
-        toast.error("스토리 등록에 실패했습니다. 다시 시도해 주세요.");
+        toast.error(status === "DRAFT" ? "임시저장에 실패했습니다." : "스토리 등록에 실패했습니다. 다시 시도해 주세요.");
       }
     });
   };
@@ -149,14 +155,15 @@ function StoryNewContent() {
           <div className="flex w-full max-w-[1040px] justify-center t:justify-end gap-4 mt-6">
             <button
               type="button"
-              onClick={handleCancel}
-              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
+              onClick={() => handleSubmit("DRAFT")}
+              disabled={createStoryMutation.isPending}
+              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-primary-1 disabled:opacity-50"
             >
               임시저장
             </button>
             <button
               type="button"
-              onClick={handleSubmit}
+              onClick={() => handleSubmit("PUBLISHED")}
               disabled={createStoryMutation.isPending}
               className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
             >

--- a/src/components/base-ui/BookStory/Common/BookStoryInfiniteList.tsx
+++ b/src/components/base-ui/BookStory/Common/BookStoryInfiniteList.tsx
@@ -102,6 +102,12 @@ const BookStoryInfiniteList: React.FC<BookStoryInfiniteListProps> = ({
         e.stopPropagation();
         onToggleLike(story.bookStoryId);
       }}
+      status={story.status}
+      canContinue={story.canContinue}
+      onContinueClick={(e) => {
+        e.stopPropagation();
+        router.push(`/stories/${story.bookStoryId}/edit`);
+      }}
     />
   );
 

--- a/src/components/base-ui/BookStory/Common/bookstory_card.tsx
+++ b/src/components/base-ui/BookStory/Common/bookstory_card.tsx
@@ -55,7 +55,7 @@ export default function BookStoryCard({
   onContinueClick,
 }: Props) {
   const heartIcon = likedByMe ? "/red_heart.svg" : "/gray_heart.svg";
-  
+
   const isLargeFixed = layoutType === "large-fixed";
   const isDraft = status === "DRAFT";
 
@@ -63,10 +63,10 @@ export default function BookStoryCard({
     <div
       onClick={onClick}
       className={`flex flex-col overflow-hidden rounded-lg border-2 border-Subbrown-4 bg-White hover:border-primary-2 transition-colors cursor-pointer
-      ${isLargeFixed 
-        ? "w-full max-w-[336px] h-[380px]" // 고정형 (기존 BookStoryCardLarge)
-        : "w-[161px] h-[243px] md:w-full md:max-w-[336px] md:h-[380px]" // 반응형
-      }`}
+      ${isLargeFixed
+          ? "w-full max-w-[336px] h-[380px]" // 고정형 (기존 BookStoryCardLarge)
+          : "w-[161px] h-[243px] md:w-full md:max-w-[336px] md:h-[380px]" // 반응형
+        }`}
     >
       {/* 1. 상단 프로필 */}
       <div className={`items-center gap-2 px-4 py-3 ${isLargeFixed ? "flex" : "hidden md:flex"}`}>
@@ -126,11 +126,6 @@ export default function BookStoryCard({
             <div className="relative w-auto h-[90%] aspect-[2/3] shadow-sm z-10 transition-transform hover:scale-105">
               <Image src={coverImgSrc} alt="cover" fill className="object-contain" />
             </div>
-            {isDraft && (
-              <div className="absolute top-2 left-2 z-20 flex px-2 py-1 items-center rounded-md bg-Secondary-1 text-White text-[10px] md:text-[12px] font-bold">
-                임시저장
-              </div>
-            )}
           </>
         )}
       </div>
@@ -144,7 +139,7 @@ export default function BookStoryCard({
           className={`text-Gray-7 truncate ${isLargeFixed
             ? "text-left subhead_2 pb-1"
             : "text-center mt-[12px] text-[14px] font-semibold leading-[145%] tracking-[-0.014px] md:text-left md:mt-0 md:subhead_2 md:pb-1"
-          }`}
+            }`}
         >
           {title}
         </p>
@@ -154,7 +149,7 @@ export default function BookStoryCard({
           className={`text-Gray-5 overflow-hidden ${isLargeFixed
             ? "h-16 pt-1 text-left body_1_3 line-clamp-3"
             : "mt-[4px] text-center text-[12px] font-medium leading-[145%] tracking-[-0.012px] line-clamp-2 md:line-clamp-3 md:block md:h-16 md:pt-1 md:text-left md:body_1_3"
-          }`}
+            }`}
         >
           {content}
         </div>
@@ -162,72 +157,69 @@ export default function BookStoryCard({
 
       {/* 4. 하단 통계 (좋아요/댓글) 또는 이어쓰기 버튼 */}
       {isDraft && canContinue ? (
-        <div className="mt-auto px-4 pb-4">
+        <div className={`mt-auto px-4 pb-4 ${isLargeFixed ? "block" : "hidden md:block"}`}>
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
               onContinueClick?.(e);
             }}
-            className="w-full h-10 rounded-lg bg-primary-2 text-White body_1_2 hover:brightness-110 active:scale-95 transition-all flex items-center justify-center gap-2"
+            className="w-full h-10 rounded-lg bg-primary-1 text-primary-3 body_1_2 hover:bg-primary-2 hover:text-White transition-colors"
           >
-            <div className="relative w-4 h-4">
-              <Image src="/pencil_icon.svg" alt="edit" fill className="object-contain brightness-0 invert" />
-            </div>
             이어쓰기
           </button>
         </div>
       ) : (
         <>
           {/* 모바일 버전 Footer (responsive 타입일 때만) */}
-      {!isLargeFixed && (
-        <div className="flex md:hidden h-[37px] items-start border-t border-Subbrown-4 pt-[4px] pb-[12px]">
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-              onLikeClick?.(e);
-            }}
-            className="flex flex-1 items-center justify-center gap-[6px] border-r-2 border-Gray-2 h-[32px] hover:bg-gray-100 transition-colors"
-          >
-            <Image src={heartIcon} alt="좋아요" width={20} height={20} />
-            <span className={`text-[12px] font-medium ${likedByMe ? 'text-primary-2' : 'text-Gray-4'}`}>
-              {likeCount}
-            </span>
-          </div>
-          <div className="flex flex-1 items-center justify-center gap-[6px] h-[32px]">
-            <Image src="/comment.svg" alt="댓글" width={20} height={20} />
-            <span className="text-[12px] font-medium text-Gray-4">
-              {commentCount}
-            </span>
-          </div>
-        </div>
-      )}
+          {!isLargeFixed && (
+            <div className="flex md:hidden h-[37px] items-start border-t border-Subbrown-4 pt-[4px] pb-[12px]">
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onLikeClick?.(e);
+                }}
+                className="flex flex-1 items-center justify-center gap-[6px] border-r-2 border-Gray-2 h-[32px] hover:bg-gray-100 transition-colors"
+              >
+                <Image src={heartIcon} alt="좋아요" width={20} height={20} />
+                <span className={`text-[12px] font-medium ${likedByMe ? 'text-primary-2' : 'text-Gray-4'}`}>
+                  {likeCount}
+                </span>
+              </div>
+              <div className="flex flex-1 items-center justify-center gap-[6px] h-[32px]">
+                <Image src="/comment.svg" alt="댓글" width={20} height={20} />
+                <span className="text-[12px] font-medium text-Gray-4">
+                  {commentCount}
+                </span>
+              </div>
+            </div>
+          )}
 
-      {/* 데스크탑 버전 Footer */}
-      <div className={`${isLargeFixed ? "grid" : "hidden md:grid"} mt-1 grid-cols-[1fr_auto_1fr] items-center px-2 pb-[10px]`}>
+          {/* 데스크탑 버전 Footer */}
+          <div className={`${isLargeFixed ? "grid" : "hidden md:grid"} mt-1 grid-cols-[1fr_auto_1fr] items-center px-2 pb-[10px]`}>
 
-        <div className="flex justify-center items-center">
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-              onLikeClick?.(e);
-            }}
-            className="flex items-center justify-center gap-2 pt-1 cursor-pointer hover:bg-gray-100 transition-colors rounded-full px-4 h-10"
-          >
-            <Image src={heartIcon} alt="좋아요" width={24} height={24} />
-            <span className={`body_1_2 ${likedByMe ? 'text-primary-2' : 'text-Gray-4'}`}>좋아요 {likeCount}</span>
+            <div className="flex justify-center items-center">
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onLikeClick?.(e);
+                }}
+                className="flex items-center justify-center gap-2 pt-1 cursor-pointer hover:bg-gray-100 transition-colors rounded-full px-4 h-10"
+              >
+                <Image src={heartIcon} alt="좋아요" width={24} height={24} />
+                <span className={`body_1_2 ${likedByMe ? 'text-primary-2' : 'text-Gray-4'}`}>좋아요 {likeCount}</span>
+              </div>
+            </div>
+            <div className="h-10 w-[1.8px] mt-2 rounded-full bg-Gray-2" />
+            <div className="flex items-center justify-center">
+              <div className="flex items-center justify-center gap-2 pt-1 px-4 h-10">
+                <Image src="/comment.svg" alt="댓글" width={24} height={24} />
+                <span className="body_1_2 text-Gray-4">댓글 {commentCount}</span>
+              </div>
+            </div>
           </div>
-        </div>
-        <div className="h-10 w-[1.8px] mt-2 rounded-full bg-Gray-2" />
-        <div className="flex items-center justify-center">
-          <div className="flex items-center justify-center gap-2 pt-1 px-4 h-10">
-            <Image src="/comment.svg" alt="댓글" width={24} height={24} />
-            <span className="body_1_2 text-Gray-4">댓글 {commentCount}</span>
-          </div>
-        </div>
-      </div>
-        </>
-      )}
+          </>
+        )}
     </div>
   );
 }

--- a/src/components/base-ui/BookStory/Common/bookstory_card.tsx
+++ b/src/components/base-ui/BookStory/Common/bookstory_card.tsx
@@ -25,6 +25,9 @@ type Props = {
   onClick?: () => void;
   onProfileClick?: () => void;
   layoutType?: "responsive" | "large-fixed";
+  status?: "PUBLISHED" | "DRAFT";
+  canContinue?: boolean;
+  onContinueClick?: (e: React.MouseEvent) => void;
 };
 
 export default function BookStoryCard({
@@ -47,10 +50,14 @@ export default function BookStoryCard({
   onClick,
   onProfileClick,
   layoutType = "responsive",
+  status = "PUBLISHED",
+  canContinue = false,
+  onContinueClick,
 }: Props) {
   const heartIcon = likedByMe ? "/red_heart.svg" : "/gray_heart.svg";
   
   const isLargeFixed = layoutType === "large-fixed";
+  const isDraft = status === "DRAFT";
 
   return (
     <div
@@ -119,6 +126,11 @@ export default function BookStoryCard({
             <div className="relative w-auto h-[90%] aspect-[2/3] shadow-sm z-10 transition-transform hover:scale-105">
               <Image src={coverImgSrc} alt="cover" fill className="object-contain" />
             </div>
+            {isDraft && (
+              <div className="absolute top-2 left-2 z-20 flex px-2 py-1 items-center rounded-md bg-Secondary-1 text-White text-[10px] md:text-[12px] font-bold">
+                임시저장
+              </div>
+            )}
           </>
         )}
       </div>
@@ -148,8 +160,26 @@ export default function BookStoryCard({
         </div>
       </div>
 
-      {/* 4. 하단 통계 (좋아요/댓글) */}
-      {/* 모바일 버전 Footer (responsive 타입일 때만) */}
+      {/* 4. 하단 통계 (좋아요/댓글) 또는 이어쓰기 버튼 */}
+      {isDraft && canContinue ? (
+        <div className="mt-auto px-4 pb-4">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onContinueClick?.(e);
+            }}
+            className="w-full h-10 rounded-lg bg-primary-2 text-White body_1_2 hover:brightness-110 active:scale-95 transition-all flex items-center justify-center gap-2"
+          >
+            <div className="relative w-4 h-4">
+              <Image src="/pencil_icon.svg" alt="edit" fill className="object-contain brightness-0 invert" />
+            </div>
+            이어쓰기
+          </button>
+        </div>
+      ) : (
+        <>
+          {/* 모바일 버전 Footer (responsive 타입일 때만) */}
       {!isLargeFixed && (
         <div className="flex md:hidden h-[37px] items-start border-t border-Subbrown-4 pt-[4px] pb-[12px]">
           <div
@@ -196,6 +226,8 @@ export default function BookStoryCard({
           </div>
         </div>
       </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/base-ui/BookStory/Common/bookstory_card.tsx
+++ b/src/components/base-ui/BookStory/Common/bookstory_card.tsx
@@ -126,6 +126,11 @@ export default function BookStoryCard({
             <div className="relative w-auto h-[90%] aspect-[2/3] shadow-sm z-10 transition-transform hover:scale-105">
               <Image src={coverImgSrc} alt="cover" fill className="object-contain" />
             </div>
+            {isDraft && (
+              <div className="absolute top-2 left-2 z-20 flex px-2 py-1 items-center rounded-md bg-Secondary-1 text-White text-[10px] md:text-[12px] font-bold">
+                임시저장
+              </div>
+            )}
           </>
         )}
       </div>
@@ -157,15 +162,18 @@ export default function BookStoryCard({
 
       {/* 4. 하단 통계 (좋아요/댓글) 또는 이어쓰기 버튼 */}
       {isDraft && canContinue ? (
-        <div className={`mt-auto px-4 pb-4 ${isLargeFixed ? "block" : "hidden md:block"}`}>
+        <div className="mt-auto px-4 pb-4">
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
               onContinueClick?.(e);
             }}
-            className="w-full h-10 rounded-lg bg-primary-1 text-primary-3 body_1_2 hover:bg-primary-2 hover:text-White transition-colors"
+            className="w-full h-10 rounded-lg bg-primary-2 text-White body_1_2 hover:brightness-110 active:scale-95 transition-all flex items-center justify-center gap-2"
           >
+            <div className="relative w-4 h-4">
+              <Image src="/pencil_icon.svg" alt="edit" fill className="object-contain brightness-0 invert" />
+            </div>
             이어쓰기
           </button>
         </div>

--- a/src/hooks/mutations/useStoryMutations.ts
+++ b/src/hooks/mutations/useStoryMutations.ts
@@ -85,8 +85,12 @@ export const useCreateBookStoryMutation = () => {
     const queryClient = useQueryClient();
     return useMutation({
         mutationFn: (data: CreateBookStoryRequest) => storyService.createBookStory(data),
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: storyKeys.all });
+        onSuccess: (_data, variables) => {
+            if (variables.status === "DRAFT") {
+                queryClient.invalidateQueries({ queryKey: storyKeys.myList() });
+            } else {
+                queryClient.invalidateQueries({ queryKey: storyKeys.all });
+            }
         },
     });
 };
@@ -98,7 +102,11 @@ export const useUpdateBookStoryMutation = () => {
             storyService.updateBookStory(args.bookStoryId, args.data),
         onSuccess: (_data, variables) => {
             queryClient.invalidateQueries({ queryKey: storyKeys.detail(variables.bookStoryId) });
-            queryClient.invalidateQueries({ queryKey: storyKeys.all });
+            if (variables.data.status === "DRAFT") {
+                queryClient.invalidateQueries({ queryKey: storyKeys.myList() });
+            } else {
+                queryClient.invalidateQueries({ queryKey: storyKeys.all });
+            }
         },
     });
 };

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -19,6 +19,8 @@ export interface BookStory {
     likedByMe: boolean;
     createdAt: string;
     writtenByMe: boolean;
+    status: "PUBLISHED" | "DRAFT";
+    canContinue: boolean;
 }
 
 export interface BookStoryListResponse {
@@ -69,12 +71,14 @@ export interface BookStoryDetail {
     comments: CommentInfo[];
     prevBookStoryId: number;
     nextBookStoryId: number;
+    status: "PUBLISHED" | "DRAFT";
 }
 
 export interface CreateBookStoryRequest {
     isbn: string;
     title: string;
-    description: string;
+    description?: string;
+    status?: "PUBLISHED" | "DRAFT";
 }
 
 export interface CreateCommentRequest {
@@ -82,5 +86,8 @@ export interface CreateCommentRequest {
 }
 
 export interface UpdateBookStoryRequest {
-    description: string;
+    isbn?: string;
+    title?: string;
+    description?: string;
+    status?: "PUBLISHED" | "DRAFT";
 }


### PR DESCRIPTION
## 📌 개요 (Summary)
책 이야기 기능의 **작성/임시저장/수정/이어쓰기** API를 통합 연동하고, 각 상태에 따른 UI 분기 및 데이터 처리 로직을 리팩토링하였습니다. 특히 임시저장(DRAFT) 글에 대한 이어쓰기 기능을 구현하여 사용자 경험을 개선했습니다.

- 관련 이슈: #316 (책 이야기 API 리팩토링 및 연동)

## 🛠️ 변경 사항 (Changes)
- [x] **새로운 기능 추가**: 
    - 책 이야기 작성 시 '임시저장(DRAFT)' 기능 추가
    - 마이페이지 내 임시저장 글에 대한 '이어쓰기' 버튼 노출 및 편집 페이지 연동
- [x] **버그 수정**: 
    - 임시저장 상태일 때 필수 필드(`description`) 유효성 검사 생략 처리
    - 글 수정 시 원본 책 정보(`isbn`, `title`) 누락 이슈 해결
- [x] **코드 리팩토링**: 
    - `isDraft`, `canContinue` 상태에 따른 카드 UI 및 페이지 버튼 UI 분기 (SoC 적용)
    - React Query Mutation 성공 시 `status`에 따른 캐시 무효화(Invalidation) 최적화
- [x] **문서 업데이트**: 
    - `src/types/story.ts` 내 API 응답 및 요청 타입 최신화

## 📸 상세 변경 내용 (Technical Details)
1. **API 페이로드 확장**
   - `status`: "PUBLISHED" | "DRAFT" 필드를 작성/수정 API에 추가하여 하나의 엔드포인트에서 두 상태를 처리하도록 구현했습니다.
2. **글 상태 기반 버튼 UI 분기**
   - `edit` 페이지에서 발행된 글은 [취소/저장], 임시저장된 글은 [임시저장/발행] 버튼이 노출되도록 개선했습니다.
3. **캐시 관리 최적화**
   - 임시저장 글 작성/수정 시에는 전체 피드가 아닌 '내 목록(`myList`)만 갱신되도록 무효화 범위를 좁혀 불필요한 네트워크 요청을 줄였습니다.
4. **마이페이지 카드 연동**
   - `BookStoryCard` 컴포넌트에서 `canContinue`가 `true`인 경우 '이어쓰기' 버튼을 동적으로 렌더링합니다.

## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build` 결과: Success)
- [x] 린트 에러가 없나요? (`pnpm lint` 확인 완료)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요? (최종 점검 완료)