### PR TITLE
fix: 소식 캐러셀 이미지 크롭 기준을 왼쪽 상단으로 변경

### DIFF
--- a/src/components/base-ui/home/Banner/NewsBannerSlider.tsx
+++ b/src/components/base-ui/home/Banner/NewsBannerSlider.tsx
@@ -65,7 +65,7 @@ export default function NewsBannerSlider() {
               src={imageSrc}
               alt={news.title}
               fill
-              className="object-cover transition-transform duration-700 group-hover:scale-105"
+              className="object-cover object-left-top transition-transform duration-700 group-hover:scale-105"
               priority={i === 0}
             />
 

--- a/src/components/base-ui/home/News/NewsBannerSlider.tsx
+++ b/src/components/base-ui/home/News/NewsBannerSlider.tsx
@@ -65,7 +65,7 @@ export default function NewsBannerSlider() {
               src={imageSrc}
               alt={news.title}
               fill
-              className="object-cover transition-transform duration-700 group-hover:scale-105"
+              className="object-cover object-left-top transition-transform duration-700 group-hover:scale-105"
               priority={i === 0}
             />
 


### PR DESCRIPTION
## 🚀 개요 (Summary)
소식 캐러셀 이미지 크롭 기준을 중앙에서 왼쪽 상단으로 변경합니다.
- 관련 이슈: #320

## 🔨 변경 사항 (Changes)
- [x] 버그 수정

`NewsBannerSlider` 컴포넌트의 이미지에 `object-left-top` 클래스를 추가하여,
모바일(297px)과 데스크탑(424px) 모두 이미지가 왼쪽 상단 기준으로 크롭되도록 수정했습니다.

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)
<img width="388" height="473" alt="image" src="https://github.com/user-attachments/assets/a0fd2270-1aef-44f9-9b73-b2b4fb1f8bda" />

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?
