### PR TITLE
fix: critical 문제 해결

### DIFF
--- a/src/components/base-ui/Profile/Follow/FollowItem.tsx
+++ b/src/components/base-ui/Profile/Follow/FollowItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { isValidUrl } from "@/utils/url";
@@ -21,10 +21,12 @@ type FollowItemProps = {
 export default function FollowItem({ user, onToggleFollow, onDelete }: FollowItemProps) {
     const isDeleted = user.isDeleted ?? false;
 
+    const isDeletingRef = useRef(false);
+
     const handleDelete = () => {
-        if (onDelete && !isDeleted) {
-            onDelete(user.nickname);
-        }
+        if (!onDelete || isDeleted || isDeletingRef.current) return;
+        isDeletingRef.current = true;
+        onDelete(user.nickname);
     };
 
     return (

--- a/src/hooks/mutations/useBookMutations.ts
+++ b/src/hooks/mutations/useBookMutations.ts
@@ -150,7 +150,7 @@ export const useToggleBookLikeMutation = () => {
                             // Inject the new book into the very first page if it's not already in the library,
                             // we are actually liking it, and we are looking at My Library
                             if (index === 0 && isMyLibrary && !isAlreadyInLibrary && fullBookToInject) {
-                                const isLikedAfterMutation = fullBookToInject.likedByMe; // This is the state *after* the mutation execution context (already toggled by previous logic)
+                                const isLikedAfterMutation = !fullBookToInject.likedByMe; // pre-toggle 값이므로 반전하여 post-toggle 상태를 구함
                                 if (isLikedAfterMutation) {
                                     // Make sure to add it as liked
                                     updatedBooks = [{ ...fullBookToInject, likedByMe: true }, ...updatedBooks];

--- a/src/hooks/mutations/useMemberMutations.ts
+++ b/src/hooks/mutations/useMemberMutations.ts
@@ -157,15 +157,6 @@ export const useToggleFollowMutation = () => {
 
     return useMutation({
         mutationFn: async ({ nickname, isFollowing }: { nickname: string; isFollowing: boolean }) => {
-            const now = Date.now();
-            const lastTime = followThrottleMap[nickname] || 0;
-
-            // Throttle: 500ms
-            if (now - lastTime < 500) {
-                return; // Ignore rapid clicks
-            }
-            followThrottleMap[nickname] = now;
-
             if (isFollowing) {
                 await memberService.unfollowMember(nickname);
             } else {
@@ -173,6 +164,12 @@ export const useToggleFollowMutation = () => {
             }
         },
         onMutate: async ({ nickname, isFollowing }) => {
+            // Throttle: 500ms — 낙관적 업데이트 자체를 막아 캐시 고착 방지
+            const now = Date.now();
+            const lastTime = followThrottleMap[nickname] || 0;
+            if (now - lastTime < 500) return;
+            followThrottleMap[nickname] = now;
+
             // Cancel outgoing refetches
             await queryClient.cancelQueries({ queryKey: storyKeys.all });
             await queryClient.cancelQueries({ queryKey: memberKeys.recommended() });
@@ -331,6 +328,7 @@ export const useDeleteFollowerMutation = () => {
                 queryKey: memberKeys.followers(),
                 refetchType: "none",
             });
+            queryClient.invalidateQueries({ queryKey: memberKeys.followCount() });
         },
         onError: (error: any, nickname, context) => {
             console.error("Failed to delete follower:", error);

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -8,8 +8,8 @@ export const isValidUrl = (url: string | null | undefined): url is string => {
     if (url.startsWith("/")) return true;
 
     try {
-        new URL(url);
-        return true; // http, https 등 유효한 scheme이 있는 경우
+        const parsed = new URL(url);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
     } catch {
         // 프로토콜 상대 URL 지원 (예: //example.com/image.png)
         if (url.startsWith("//")) {


### PR DESCRIPTION
## 📌 개요 (Summary)
- 프로젝트 내 발생하던 보안 취약점 해결 및 데이터 정합성(낙관적 업데이트 로직, 스로틀 상태 제어, 중복 호출 방지) 관련 크리티컬 이슈들을 핫픽스 처리했습니다.
- 관련 이슈: #324 (보안 및 데이터 정합성 크리티컬 버그 수정)

---

## 🛠️ 변경 사항 (Changes)

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타

### 1. 보안 스키마 차단 구현 (`src/utils/url.ts`)
- **문제 상황**: 기존 `new URL()` 파싱 검증은 `javascript:`, `data:`, `ftp:` 등 보안상 취약할 수 있는 스키마들을 유효한 URL로 판정하고 통과시켰습니다. Next.js Image 컴포넌트나 외부 Link에서 이를 신뢰할 시 XSS 취약점에 노출될 위험이 존재했습니다.
- **수정 내용**: URL 파싱 성공 후, 프로토콜이 `http:` 또는 `https:`인 스키마에 대해서만 `true`를 반환하도록 스키마를 명확히 제한했습니다. (단, `/` 및 `//`로 시작하는 로컬 경로와 프로토콜 상대 경로는 기존대로 허용)

### 2. 내 서재 `likedBooks` 낙관적 업데이트 인젝션 버그 수정 (`src/hooks/mutations/useBookMutations.ts`)
- **문제 상황**: 도서 좋아요 클릭 시 `fullBookToInject`가 토글 이전 상태(`pre-toggle`) 기준으로 캡처되었습니다. 이에 따라 `likedByMe` 필드 역시 토글 전 값으로 고정되어, 실제 "좋아요"를 등록했음에도 캐시 주입 조건문이 오동작하여 내 서재에 반영되지 않는 문제가 있었습니다.
- **수정 내용**: 토글 전 상태 값을 반전하여 실제 최종 상태(`post-toggle`이 `likedByMe: true`) 상태를 안전하게 판별하도록 인젝션 조건을 수정했습니다. 
- *참고*: "좋아요 취소" 시에는 하트 색상만 즉시 변경되고, 다른 탭으로 이동하거나 재진입할 때 갱신되도록 한 기존 설계 의도(Option B)를 완벽히 유지했습니다.

### 3. 팔로우 캐시 영구 고착 버그 해결 (`src/hooks/mutations/useMemberMutations.ts`)
- **문제 상황**: API 스로틀(Throttle) 검사가 `mutationFn`에서 수행되었기 때문에, `onMutate`에 의해 UI 낙관적 업데이트가 먼저 선행되었습니다. 이 상태에서 빠른 클릭에 의해 스로틀이 감지되면 API 호출만 조용히 차단되고, 캐시는 롤백되지 않고 낙관적 데이터 상태 그대로 고착되는 버그가 발생했습니다.
- **수정 내용**: 스로틀 검사를 `onMutate` 최상단으로 이동시켰습니다. 스로틀 제한에 걸린 클릭은 낙관적 캐시 수정 단계 진입 자체를 차단하여, 불필요한 캐시 오염 및 UI 영구 불일치 현상을 근본적으로 차단했습니다.

### 4. 팔로워 삭제 시 팔로워 숫자 동기화 추가 (`src/hooks/mutations/useMemberMutations.ts`)
- **문제 상황**: 팔로워 삭제(`useDeleteFollowerMutation`) 요청 성공 후 `followers` 캐시 쿼리만 무효화(invalidate)되어, 프로필 정보 상단의 팔로워 카운트(`followCount`) 쿼리가 최신화되지 않고 정체되었습니다.
- **수정 내용**: `onSuccess` 콜백 함수 내에 `memberKeys.followCount()` 무효화 구문을 추가하여 팔로워 수 정보가 즉각적으로 동기화되도록 수정했습니다.

### 5. 구독자 삭제 API 중복 호출 차단 (`src/components/base-ui/Profile/Follow/FollowItem.tsx`)
- **문제 상황**: '삭제' 버튼 클릭 시 `user.isDeleted` 프로필 정보의 상태가 갱신되기 전, 연타로 더블클릭할 경우 서버에 동일한 팔로워 삭제 API 요청이 중복되어 전송되는 레이스 컨디션이 우려되었습니다.
- **수정 내용**: React `useRef`를 사용하여 비동기 삭제 작업이 처리 중인지 여부를 저장하는 `isDeletingRef` 가드를 추가했습니다. 통신 중일 때 들어오는 추가 클릭 동작을 완벽히 차단하여 불필요한 API 트래픽 발생을 예방했습니다.

---

## 📸 스크린샷 (Screenshots)
*(UI 레이아웃의 구조적인 변경이 없는 데이터/보안 버그 수정으로 스크린샷은 생략합니다.)*

---

## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build` 정상 완료)
- [x] 린트 에러가 없나요? (`pnpm lint` 통과 확인)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요? (작업에 무관한 코드 침범 없음, Surgical Change 준수)