### PR TITLE
fix: 랜딩페이지 버튼 hover 커서 및 시각 효과 추가

### DIFF
--- a/src/components/base-ui/Landing/LandingChatSection.tsx
+++ b/src/components/base-ui/Landing/LandingChatSection.tsx
@@ -291,7 +291,7 @@ export default function LandingChatSection() {
           </div>
           <button
             onClick={handleJoin}
-            className="subhead_3_2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition-all hover:brightness-110 hover:shadow-lg active:scale-95"
+            className="subhead_3_2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition hover:brightness-110 hover:shadow-lg active:scale-95"
           >
             지금 가입하기
           </button>

--- a/src/components/base-ui/Landing/LandingChatSection.tsx
+++ b/src/components/base-ui/Landing/LandingChatSection.tsx
@@ -291,7 +291,7 @@ export default function LandingChatSection() {
           </div>
           <button
             onClick={handleJoin}
-            className="subhead_3_2 rounded-full bg-primary-1 px-8 py-3.5 text-white transition-opacity hover:opacity-80"
+            className="subhead_3_2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition-all hover:brightness-110 hover:shadow-lg active:scale-95"
           >
             지금 가입하기
           </button>

--- a/src/components/base-ui/Landing/LandingHero.tsx
+++ b/src/components/base-ui/Landing/LandingHero.tsx
@@ -53,7 +53,7 @@ export default function LandingHero() {
 
         <button
           onClick={handleJoin}
-          className="subhead_3_2 mt-2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition-all hover:brightness-110 hover:shadow-lg active:scale-95"
+          className="subhead_3_2 mt-2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition hover:brightness-110 hover:shadow-lg active:scale-95"
         >
           지금 가입하기
         </button>

--- a/src/components/base-ui/Landing/LandingHero.tsx
+++ b/src/components/base-ui/Landing/LandingHero.tsx
@@ -53,7 +53,7 @@ export default function LandingHero() {
 
         <button
           onClick={handleJoin}
-          className="subhead_3_2 mt-2 rounded-full bg-primary-1 px-8 py-3.5 text-white transition-opacity hover:opacity-80"
+          className="subhead_3_2 mt-2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition-all hover:brightness-110 hover:shadow-lg active:scale-95"
         >
           지금 가입하기
         </button>

--- a/src/components/base-ui/Landing/LandingNav.tsx
+++ b/src/components/base-ui/Landing/LandingNav.tsx
@@ -47,7 +47,7 @@ export default function LandingNav() {
           </Link>
           <button
             onClick={handleLogin}
-            className="body_2_1 rounded-full bg-primary-1 px-4 py-1.5 text-white transition-opacity hover:opacity-80 t:body_1_1 t:px-5 t:py-2"
+            className="body_2_1 cursor-pointer rounded-full bg-primary-1 px-4 py-1.5 text-white transition-all hover:brightness-110 hover:shadow-md active:scale-95 t:body_1_1 t:px-5 t:py-2"
           >
             로그인/회원가입
           </button>

--- a/src/components/base-ui/Landing/LandingNav.tsx
+++ b/src/components/base-ui/Landing/LandingNav.tsx
@@ -47,7 +47,7 @@ export default function LandingNav() {
           </Link>
           <button
             onClick={handleLogin}
-            className="body_2_1 cursor-pointer rounded-full bg-primary-1 px-4 py-1.5 text-white transition-all hover:brightness-110 hover:shadow-md active:scale-95 t:body_1_1 t:px-5 t:py-2"
+            className={`body_2_1 cursor-pointer rounded-full px-4 py-1.5 transition hover:brightness-110 active:scale-95 t:body_1_1 t:px-5 t:py-2 ${scrolled ? "bg-white text-primary-1 shadow-md" : "bg-primary-1 text-white hover:shadow-md"}`}
           >
             로그인/회원가입
           </button>

--- a/src/components/base-ui/Landing/LandingNav.tsx
+++ b/src/components/base-ui/Landing/LandingNav.tsx
@@ -47,7 +47,11 @@ export default function LandingNav() {
           </Link>
           <button
             onClick={handleLogin}
-            className={`body_2_1 cursor-pointer rounded-full px-4 py-1.5 transition hover:brightness-110 active:scale-95 t:body_1_1 t:px-5 t:py-2 ${scrolled ? "bg-white text-primary-1 shadow-md" : "bg-primary-1 text-white hover:shadow-md"}`}
+            className={`body_2_1 cursor-pointer rounded-full px-4 py-1.5 transition-all active:scale-95 t:body_1_1 t:px-5 t:py-2 ${
+              scrolled
+                ? "bg-white text-primary-1 hover:bg-white/90 hover:shadow-md"
+                : "bg-primary-1 text-white hover:brightness-110 hover:shadow-md"
+            }`}
           >
             로그인/회원가입
           </button>


### PR DESCRIPTION
## 🚀 개요 (Summary)
랜딩페이지 버튼 hover 시 커서 및 시각적 피드백 효과 누락 수정 (#333 )

## 🛠 변경 사항 (Changes)
- [x] 버그 수정

랜딩페이지 내 3개 버튼에 hover/active 효과 추가
- `LandingNav` — 로그인/회원가입 버튼
- `LandingHero` — 지금 가입하기 버튼 (상단)
- `LandingChatSection` — 지금 가입하기 버튼 (하단)

변경 내용:
- `cursor-pointer` 추가 (hover 시 손가락 커서)
- `hover:brightness-110` + `hover:shadow-md/lg` (버튼 밝아지며 그림자)
- `active:scale-95` (클릭 시 눌리는 피드백)
- `transition-all` 적용으로 모든 효과 부드럽게 전환

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?
