### PR TITLE
Feat/326 modified api

### DIFF
--- a/src/app/(main)/setting/block/page.tsx
+++ b/src/app/(main)/setting/block/page.tsx
@@ -1,27 +1,25 @@
 "use client";
 
+import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
 import SettingsDetailLayout from "@/components/base-ui/Settings/SettingsDetailLayout";
 import BlockedUserItem from "@/components/base-ui/Settings/Block/BlockedUserItem";
-import { useInView } from "react-intersection-observer";
-import { useState } from "react";
+import { useBlockedUsersQuery } from "@/hooks/queries/useMemberQueries";
+import { useUnblockMemberMutation } from "@/hooks/mutations/useMemberMutations";
 
 export default function BlockPage() {
-  // const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } = useBlockedUsersQuery();
-  const { ref } = useInView();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
+    useBlockedUsersQuery();
+  const { mutate: unblock } = useUnblockMemberMutation();
+  const { ref, inView } = useInView();
 
-  // API 미구현으로 인한 임시 상태 및 핸들러 (리뷰 반영: Mock 데이터 도입)
-  const [isLoading] = useState(false);
-  const [isError] = useState(false);
-  const [blockedUsers, setBlockedUsers] = useState([
-    { id: 1, nickname: "북클럽_매니아", profileImageUrl: "" },
-    { id: 2, nickname: "책읽는_고양이", profileImageUrl: "" },
-    { id: 3, nickname: "독서왕_제이", profileImageUrl: "" },
-  ]);
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const handleUnblock = (id: number) => {
-    // TODO: 차단 해제 API 연동 (현재는 로컬 Mock 상태에서만 삭제)
-    setBlockedUsers((prev) => prev.filter((user) => user.id !== id));
-  };
+  const blockedUsers = data?.pages.flatMap((page) => page.blocks) ?? [];
 
   if (isLoading) {
     return (
@@ -53,10 +51,10 @@ export default function BlockPage() {
         <div className="flex flex-col gap-[8px] w-full">
           {blockedUsers.map((user) => (
             <BlockedUserItem
-              key={user.id}
+              key={user.memberId}
               nickname={user.nickname}
-              profileImageUrl={user.profileImageUrl}
-              onUnblock={() => handleUnblock(user.id)}
+              profileImageUrl={user.profileImageUrl ?? undefined}
+              onUnblock={() => unblock(user.nickname)}
             />
           ))}
         </div>

--- a/src/app/(main)/stories/[id]/page.tsx
+++ b/src/app/(main)/stories/[id]/page.tsx
@@ -12,6 +12,7 @@ import { isValidUrl } from "@/utils/url";
 import { useParams, useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import { useAuthStore } from "@/store/useAuthStore";
+import { getErrorMessage } from "@/lib/api/errors";
 
 import {
   useStoryDetailQuery,
@@ -79,10 +80,8 @@ export default function StoryDetailPage() {
     // TODO: PM 요청 시 차단 상태별 메시지 수정 필요 (BLOCK_404: 내가 차단, BLOCK_405: 상대가 차단)
     const apiError = error as { code?: string } | null;
     const message =
-      apiError?.code === "BLOCK_404"
-        ? "차단한 사용자입니다."
-        : apiError?.code === "BLOCK_405"
-        ? "조회가 불가능한 프로필입니다."
+      (apiError?.code === "BLOCK_404" || apiError?.code === "BLOCK_405")
+        ? getErrorMessage(apiError.code)
         : "해당 책 이야기를 찾을 수 없습니다.";
     return (
       <div className="flex flex-col items-center justify-center min-h-[400px]">

--- a/src/app/(main)/stories/[id]/page.tsx
+++ b/src/app/(main)/stories/[id]/page.tsx
@@ -39,7 +39,7 @@ export default function StoryDetailPage() {
     );
   }
 
-  const { data: story, isLoading, isError } = useStoryDetailQuery(storyId);
+  const { data: story, isLoading, isError, error } = useStoryDetailQuery(storyId);
   const { mutate: toggleLike } = useToggleStoryLikeMutation();
   const { mutate: deleteStory, isPending: isDeletePending } = useDeleteBookStoryMutation();
   const { mutate: toggleFollow } = useToggleFollowMutation();
@@ -76,10 +76,18 @@ export default function StoryDetailPage() {
 
   // 스토리가 없으면 404 UI
   if (!story || isError) {
+    // TODO: PM 요청 시 차단 상태별 메시지 수정 필요 (BLOCK_404: 내가 차단, BLOCK_405: 상대가 차단)
+    const apiError = error as { code?: string } | null;
+    const message =
+      apiError?.code === "BLOCK_404"
+        ? "차단한 사용자입니다."
+        : apiError?.code === "BLOCK_405"
+        ? "조회가 불가능한 프로필입니다."
+        : "해당 책 이야기를 찾을 수 없습니다.";
     return (
       <div className="flex flex-col items-center justify-center min-h-[400px]">
         <h2 className="text-2xl font-bold text-Gray-7 mb-4">404</h2>
-        <p className="text-Gray-5">해당 책 이야기를 찾을 수 없습니다.</p>
+        <p className="text-Gray-5">{message}</p>
       </div>
     );
   }

--- a/src/components/base-ui/Comment/comment_item.tsx
+++ b/src/components/base-ui/Comment/comment_item.tsx
@@ -15,6 +15,7 @@ type CommentItemProps = {
   createdAt: string;
   isAuthor?: boolean; // 작성자 뱃지용
   isMine?: boolean;
+  isBlocked?: boolean; // 차단된 사용자의 댓글
   isReply?: boolean;
   canEdit?: boolean;
   canDelete?: boolean;
@@ -34,6 +35,7 @@ export default function CommentItem({
   createdAt,
   isAuthor = false,
   isMine = false,
+  isBlocked = false,
   isReply = false,
   canEdit = false,
   canDelete = false,
@@ -79,7 +81,7 @@ export default function CommentItem({
 
       {!isEditing ? (
         <div className="flex items-start justify-between gap-2">
-          <p className="Body_1_2 text-Gray-5 flex-1 whitespace-pre-wrap">
+          <p className={`Body_1_2 flex-1 whitespace-pre-wrap ${isBlocked ? "text-Gray-3 italic" : "text-Gray-5"}`}>
             {content}
           </p>
           {hasMenuAction && (

--- a/src/components/base-ui/Comment/comment_list.tsx
+++ b/src/components/base-ui/Comment/comment_list.tsx
@@ -14,6 +14,7 @@ export type Comment = {
   createdAt: string;
   isAuthor?: boolean; // 글 작성자인지 (뱃지용)
   isMine?: boolean; // 내가 쓴 댓글인지
+  isBlocked?: boolean; // 차단된 사용자의 댓글인지 (서버에서 "차단된 사용자입니다"로 마스킹)
   parentCommentId?: number | null;
   replies?: Comment[];
 };
@@ -107,11 +108,12 @@ export default function CommentList({
                 createdAt={comment.createdAt}
                 isAuthor={comment.isAuthor}
                 isMine={comment.isMine}
-                onReply={handleReplyClick}
+                isBlocked={comment.isBlocked}
+                onReply={comment.isBlocked ? undefined : handleReplyClick}
                 onEdit={onEditComment}
                 onDelete={onDeleteComment}
-                onReport={onReportComment}
-                onProfileClick={onProfileClick}
+                onReport={comment.isBlocked ? undefined : onReportComment}
+                onProfileClick={comment.isBlocked ? undefined : onProfileClick}
               />
 
               {/* 답글 입력창  */}
@@ -169,11 +171,12 @@ export default function CommentList({
                     createdAt={reply.createdAt}
                     isAuthor={reply.isAuthor}
                     isMine={reply.isMine}
+                    isBlocked={reply.isBlocked}
                     isReply
                     onEdit={onEditComment}
                     onDelete={onDeleteComment}
-                    onReport={onReportComment}
-                    onProfileClick={onProfileClick}
+                    onReport={reply.isBlocked ? undefined : onReportComment}
+                    onProfileClick={reply.isBlocked ? undefined : onProfileClick}
                   />
                 </div>
               ))}

--- a/src/components/base-ui/Comment/comment_section_bookcase.tsx
+++ b/src/components/base-ui/Comment/comment_section_bookcase.tsx
@@ -51,6 +51,8 @@ export default function CommentSection({
       createdAt: c.createdAt,
       isAuthor: c.authorInfo?.nickname === storyAuthorNickname,
       isMine: c.writtenByMe,
+      // 서버에서 content와 nickname 모두 "차단된 사용자입니다"로 마스킹하여 내려옴
+      isBlocked: !c.deleted && c.authorInfo?.nickname === "차단된 사용자입니다",
       replies: c.replies ? c.replies.map(r => mapNode(r)) : [],
       parentCommentId: c.parentCommentId,
     });
@@ -123,8 +125,12 @@ export default function CommentSection({
         onSuccess: () => {
           toast.success("댓글이 등록되었습니다.");
         },
-        onError: () => {
-          toast.error("댓글 등록에 실패했습니다.");
+        onError: (err: any) => {
+          if (err?.code === "COMMENT_405") {
+            toast.error("차단 관계가 있는 회원에게는 댓글을 작성할 수 없습니다.");
+          } else {
+            toast.error("댓글 등록에 실패했습니다.");
+          }
         }
       }
     );
@@ -142,8 +148,12 @@ export default function CommentSection({
         onSuccess: () => {
           toast.success("답글이 등록되었습니다.");
         },
-        onError: () => {
-          toast.error("답글 등록에 실패했습니다.");
+        onError: (err: any) => {
+          if (err?.code === "COMMENT_405") {
+            toast.error("차단 관계가 있는 회원에게는 댓글을 작성할 수 없습니다.");
+          } else {
+            toast.error("답글 등록에 실패했습니다.");
+          }
         }
       }
     );

--- a/src/components/base-ui/Comment/comment_section_bookcase.tsx
+++ b/src/components/base-ui/Comment/comment_section_bookcase.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/navigation";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
 import { BLOCKED_USER_MASK } from "@/constants/masking";
 import { useBlockStore } from "@/store/useBlockStore";
+import { hasErrorCode } from "@/lib/api/errors";
 
 // 어떤 글의 댓글인지 구분
 type CommentSectionProps = {
@@ -112,6 +113,15 @@ export default function CommentSection({
     return rootComments;
   };
 
+  // 댓글/답글 등록 실패 시 공통 에러 핸들러
+  const handleCommentError = (err: unknown, defaultMessage: string) => {
+    if (hasErrorCode(err) && err.code === "COMMENT_405") {
+      toast.error("차단 관계가 있는 회원에게는 댓글을 작성할 수 없습니다.");
+      return;
+    }
+    toast.error(defaultMessage);
+  };
+
   const [comments, setComments] = useState<Comment[]>(() => mapApiToUiComments(initialComments));
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [commentToDelete, setCommentToDelete] = useState<number | null>(null);
@@ -137,12 +147,8 @@ export default function CommentSection({
         onSuccess: () => {
           toast.success("댓글이 등록되었습니다.");
         },
-        onError: (err: any) => {
-          if (err?.code === "COMMENT_405") {
-            toast.error("차단 관계가 있는 회원에게는 댓글을 작성할 수 없습니다.");
-          } else {
-            toast.error("댓글 등록에 실패했습니다.");
-          }
+        onError: (err: unknown) => {
+          handleCommentError(err, "댓글 등록에 실패했습니다.");
         }
       }
     );
@@ -160,12 +166,8 @@ export default function CommentSection({
         onSuccess: () => {
           toast.success("답글이 등록되었습니다.");
         },
-        onError: (err: any) => {
-          if (err?.code === "COMMENT_405") {
-            toast.error("차단 관계가 있는 회원에게는 댓글을 작성할 수 없습니다.");
-          } else {
-            toast.error("답글 등록에 실패했습니다.");
-          }
+        onError: (err: unknown) => {
+          handleCommentError(err, "답글 등록에 실패했습니다.");
         }
       }
     );

--- a/src/components/base-ui/Comment/comment_section_bookcase.tsx
+++ b/src/components/base-ui/Comment/comment_section_bookcase.tsx
@@ -17,6 +17,8 @@ import { ReportType } from "@/types/member";
 import { useAuthStore } from "@/store/useAuthStore";
 import { useRouter } from "next/navigation";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { BLOCKED_USER_MASK } from "@/constants/masking";
+import { useBlockStore } from "@/store/useBlockStore";
 
 // 어떤 글의 댓글인지 구분
 type CommentSectionProps = {
@@ -37,6 +39,13 @@ export default function CommentSection({
   const { mutate: reportMember } = useReportMemberMutation();
   const { isLoggedIn, openLoginModal } = useAuthStore();
   const router = useRouter();
+  const { isBlocked: checkLocalBlocked, initializeBlocks } = useBlockStore();
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      initializeBlocks();
+    }
+  }, [isLoggedIn, initializeBlocks]);
 
   // API 데이터를 UI용 Comment 형식으로 변환 및 계층 구조화
   const mapApiToUiComments = (apiComments: CommentInfo[]): Comment[] => {
@@ -51,8 +60,11 @@ export default function CommentSection({
       createdAt: c.createdAt,
       isAuthor: c.authorInfo?.nickname === storyAuthorNickname,
       isMine: c.writtenByMe,
-      // 서버에서 content와 nickname 모두 "차단된 사용자입니다"로 마스킹하여 내려옴
-      isBlocked: !c.deleted && c.authorInfo?.nickname === "차단된 사용자입니다",
+      // 서버에서 content와 nickname 모두 BLOCKED_USER_MASK로 마스킹하여 내려오거나, 로컬에서 차단한 경우 즉시 마스킹
+      isBlocked: !c.deleted && (
+        c.authorInfo?.nickname === BLOCKED_USER_MASK ||
+        (c.authorInfo?.nickname ? checkLocalBlocked(c.authorInfo.nickname) : false)
+      ),
       replies: c.replies ? c.replies.map(r => mapNode(r)) : [],
       parentCommentId: c.parentCommentId,
     });

--- a/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
+++ b/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import { useOtherProfileQuery } from "@/hooks/queries/useMemberQueries";
 
-import { useToggleFollowMutation, useReportMemberMutation } from "@/hooks/mutations/useMemberMutations";
+import { useToggleFollowMutation, useReportMemberMutation, useBlockMemberMutation } from "@/hooks/mutations/useMemberMutations";
 import { ReportType } from "@/types/member";
 import ReportModal from "@/components/common/modals/report-block/ReportModal";
 import { useAuthStore } from "@/store/useAuthStore";
@@ -60,10 +60,11 @@ function StatItem({ label, count, href }: { label: string; count: number, href: 
 }
 
 export default function ProfileUserInfo({ nickname }: { nickname: string }) {
-  const { data: profile, isLoading } = useOtherProfileQuery(nickname);
+  const { data: profile, isLoading, isError, error } = useOtherProfileQuery(nickname);
   const { isLoggedIn, openLoginModal } = useAuthStore();
   const { mutate: toggleFollow } = useToggleFollowMutation();
   const { mutate: reportMember } = useReportMemberMutation();
+  const { mutateAsync: blockMember } = useBlockMemberMutation();
   
   const handleReportSubmitLogic = (type: string, content: string) => {
     const mappedType = REPORT_TYPE_MAP[type] || "GENERAL";
@@ -76,13 +77,7 @@ export default function ProfileUserInfo({ nickname }: { nickname: string }) {
   };
 
   const handleBlockSubmitLogic = async () => {
-    // TODO: 실제 차단 API 연동 (현재는 Mock 처리)
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        console.log("Member blocked:", nickname);
-        resolve();
-      }, 1000);
-    });
+    await blockMember(nickname);
   };
 
   const {
@@ -103,10 +98,18 @@ export default function ProfileUserInfo({ nickname }: { nickname: string }) {
     );
   }
 
-  if (!profile) {
+  if (isError || !profile) {
+    // TODO: PM 요청 시 차단 상태별 메시지 수정 필요 (BLOCK_404: 내가 차단, BLOCK_405: 상대가 차단)
+    const apiError = error as { code?: string } | null;
+    const message =
+      apiError?.code === "BLOCK_404"
+        ? "차단한 사용자입니다."
+        : apiError?.code === "BLOCK_405"
+        ? "조회가 불가능한 프로필입니다."
+        : "프로필 정보를 불러올 수 없습니다.";
     return (
       <div className="flex justify-center items-center py-10 text-Gray-5 body_1 min-h-[200px]">
-        프로필 정보를 불러올 수 없습니다.
+        {message}
       </div>
     );
   }

--- a/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
+++ b/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
@@ -13,6 +13,7 @@ import ActionSelectionModal from "@/components/common/modals/report-block/Action
 import BlockConfirmModal from "@/components/common/modals/report-block/BlockConfirmModal";
 import { useReportBlockFlow } from "@/hooks/useReportBlockFlow";
 import { REPORT_TYPE_MAP } from "@/constants/report";
+import { getErrorMessage } from "@/lib/api/errors";
 
 // [보조 컴포넌트] 액션 버튼 (구독하기 / 신고하기)
 function ActionButton({
@@ -102,10 +103,8 @@ export default function ProfileUserInfo({ nickname }: { nickname: string }) {
     // TODO: PM 요청 시 차단 상태별 메시지 수정 필요 (BLOCK_404: 내가 차단, BLOCK_405: 상대가 차단)
     const apiError = error as { code?: string } | null;
     const message =
-      apiError?.code === "BLOCK_404"
-        ? "차단한 사용자입니다."
-        : apiError?.code === "BLOCK_405"
-        ? "조회가 불가능한 프로필입니다."
+      (apiError?.code === "BLOCK_404" || apiError?.code === "BLOCK_405")
+        ? getErrorMessage(apiError.code)
         : "프로필 정보를 불러올 수 없습니다.";
     return (
       <div className="flex justify-center items-center py-10 text-Gray-5 body_1 min-h-[200px]">

--- a/src/constants/masking.ts
+++ b/src/constants/masking.ts
@@ -1,0 +1,1 @@
+export const BLOCKED_USER_MASK = "차단된 사용자입니다";

--- a/src/hooks/mutations/useMemberMutations.ts
+++ b/src/hooks/mutations/useMemberMutations.ts
@@ -390,3 +390,41 @@ export const useWithdrawMutation = () => {
         },
     });
 };
+
+export const useBlockMemberMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (nickname: string) => {
+            await memberService.blockMember(nickname);
+        },
+        onSuccess: () => {
+            toast.success("차단이 완료되었습니다.");
+            queryClient.invalidateQueries({ queryKey: memberKeys.blocks() });
+        },
+        onError: (error: any) => {
+            console.error("Failed to block member:", error);
+            const errorMessage = error.response?.data?.message || error.message || "차단에 실패했습니다.";
+            toast.error(errorMessage);
+        },
+    });
+};
+
+export const useUnblockMemberMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (nickname: string) => {
+            await memberService.unblockMember(nickname);
+        },
+        onSuccess: () => {
+            toast.success("차단이 해제되었습니다.");
+            queryClient.invalidateQueries({ queryKey: memberKeys.blocks() });
+        },
+        onError: (error: any) => {
+            console.error("Failed to unblock member:", error);
+            const errorMessage = error.response?.data?.message || error.message || "차단 해제에 실패했습니다.";
+            toast.error(errorMessage);
+        },
+    });
+};

--- a/src/hooks/mutations/useMemberMutations.ts
+++ b/src/hooks/mutations/useMemberMutations.ts
@@ -6,6 +6,7 @@ import { authService } from "@/services/authService";
 import { useAuthStore } from "@/store/useAuthStore";
 import { ReportMemberRequest, FollowListResponse } from "@/types/member";
 import { memberKeys } from "../queries/useMemberQueries";
+import { useBlockStore } from "@/store/useBlockStore";
 
 interface UpdateProfilePayload {
     description: string;
@@ -399,8 +400,9 @@ export const useBlockMemberMutation = () => {
         mutationFn: async (nickname: string) => {
             await memberService.blockMember(nickname);
         },
-        onSuccess: () => {
+        onSuccess: (_data, nickname) => {
             showCustomToast("차단이 완료되었습니다.");
+            useBlockStore.getState().addBlockedNickname(nickname);
             queryClient.invalidateQueries({ queryKey: memberKeys.blocks() });
             queryClient.invalidateQueries({ queryKey: storyKeys.all, refetchType: 'none' });
         },
@@ -419,8 +421,9 @@ export const useUnblockMemberMutation = () => {
         mutationFn: async (nickname: string) => {
             await memberService.unblockMember(nickname);
         },
-        onSuccess: () => {
+        onSuccess: (_data, nickname) => {
             showCustomToast("차단이 해제되었습니다.");
+            useBlockStore.getState().removeBlockedNickname(nickname);
             queryClient.invalidateQueries({ queryKey: memberKeys.blocks() });
             queryClient.invalidateQueries({ queryKey: storyKeys.all, refetchType: 'none' });
         },

--- a/src/hooks/mutations/useMemberMutations.ts
+++ b/src/hooks/mutations/useMemberMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient, InfiniteData } from "@tanstack/react-query";
-import toast from "react-hot-toast";
 import { memberService } from "@/services/memberService";
+import { toast } from "react-hot-toast";
+import { showCustomToast } from "@/utils/toastUtils";
 import { authService } from "@/services/authService";
 import { useAuthStore } from "@/store/useAuthStore";
 import { ReportMemberRequest, FollowListResponse } from "@/types/member";
@@ -399,8 +400,9 @@ export const useBlockMemberMutation = () => {
             await memberService.blockMember(nickname);
         },
         onSuccess: () => {
-            toast.success("차단이 완료되었습니다.");
+            showCustomToast("차단이 완료되었습니다.");
             queryClient.invalidateQueries({ queryKey: memberKeys.blocks() });
+            queryClient.invalidateQueries({ queryKey: storyKeys.all, refetchType: 'none' });
         },
         onError: (error: any) => {
             console.error("Failed to block member:", error);
@@ -418,8 +420,9 @@ export const useUnblockMemberMutation = () => {
             await memberService.unblockMember(nickname);
         },
         onSuccess: () => {
-            toast.success("차단이 해제되었습니다.");
+            showCustomToast("차단이 해제되었습니다.");
             queryClient.invalidateQueries({ queryKey: memberKeys.blocks() });
+            queryClient.invalidateQueries({ queryKey: storyKeys.all, refetchType: 'none' });
         },
         onError: (error: any) => {
             console.error("Failed to unblock member:", error);

--- a/src/hooks/mutations/useStoryMutations.ts
+++ b/src/hooks/mutations/useStoryMutations.ts
@@ -3,6 +3,7 @@ import { storyService } from "@/services/storyService";
 import { CreateBookStoryRequest, storyKeys } from "@/hooks/queries/useStoryQueries";
 import { toast } from "react-hot-toast";
 import { BookStoryListResponse, BookStoryDetail, UpdateBookStoryRequest } from "@/types/story";
+import { hasErrorCode } from "@/lib/api/errors";
 
 const updateLikeInStoryList = (old: BookStoryListResponse | undefined, bookStoryId: number) => {
     if (!old || !old.basicInfoList) return old;
@@ -284,10 +285,10 @@ export const useToggleStoryLikeMutation = () => {
                 toast.success("좋아요가 취소되었습니다.");
             }
         },
-        onError: (err: any, bookStoryId, context) => {
+        onError: (err: unknown, bookStoryId, context) => {
             console.error("Failed to toggle like:", err);
             // BOOK_STORY_408: 차단 관계에서 새 좋아요 시도 시
-            if (err?.code === "BOOK_STORY_408") {
+            if (hasErrorCode(err) && err.code === "BOOK_STORY_408") {
                 toast.error("차단 관계가 있는 회원의 책 이야기에는 좋아요를 누를 수 없습니다.");
             } else {
                 toast.error("좋아요 상태 업데이트에 실패했습니다.");

--- a/src/hooks/mutations/useStoryMutations.ts
+++ b/src/hooks/mutations/useStoryMutations.ts
@@ -284,9 +284,14 @@ export const useToggleStoryLikeMutation = () => {
                 toast.success("좋아요가 취소되었습니다.");
             }
         },
-        onError: (err, bookStoryId, context) => {
+        onError: (err: any, bookStoryId, context) => {
             console.error("Failed to toggle like:", err);
-            toast.error("좋아요 상태 업데이트에 실패했습니다.");
+            // BOOK_STORY_408: 차단 관계에서 새 좋아요 시도 시
+            if (err?.code === "BOOK_STORY_408") {
+                toast.error("차단 관계가 있는 회원의 책 이야기에는 좋아요를 누를 수 없습니다.");
+            } else {
+                toast.error("좋아요 상태 업데이트에 실패했습니다.");
+            }
 
             if (context?.previousInfiniteStories) {
                 queryClient.setQueryData(storyKeys.infiniteList(), context.previousInfiniteStories);

--- a/src/hooks/queries/useMemberQueries.ts
+++ b/src/hooks/queries/useMemberQueries.ts
@@ -11,6 +11,7 @@ export const memberKeys = {
     followCount: () => [...memberKeys.all, "follow-count"] as const,
     reports: () => [...memberKeys.all, "reports"] as const,
     loginStatus: () => [...memberKeys.all, "login-status"] as const,
+    blocks: () => [...memberKeys.all, "blocks"] as const,
 };
 
 export const useRecommendedMembersQuery = (enabled: boolean = true) => {
@@ -79,6 +80,16 @@ export const useLoginStatusQuery = (enabled: boolean = true) => {
     return useQuery({
         queryKey: memberKeys.loginStatus(),
         queryFn: () => memberService.getLoginStatus(),
+        enabled,
+    });
+};
+
+export const useBlockedUsersQuery = (enabled: boolean = true) => {
+    return useInfiniteQuery({
+        queryKey: memberKeys.blocks(),
+        queryFn: ({ pageParam }) => memberService.getBlockedList(pageParam),
+        initialPageParam: undefined as number | undefined,
+        getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor ?? undefined : undefined),
         enabled,
     });
 };

--- a/src/hooks/useReportBlockFlow.ts
+++ b/src/hooks/useReportBlockFlow.ts
@@ -28,7 +28,7 @@ export function useReportBlockFlow(
       }
 
       closeAll();
-      showCustomToast("차단이 완료되었습니다.");
+      // showCustomToast는 useBlockMemberMutation.onSuccess에서 이미 호출되므로 여기서 제거
     } catch (error) {
       console.error("Block action failed:", error);
       // 필요 시 에러 토스트 추가 가능

--- a/src/lib/api/endpoints/member.ts
+++ b/src/lib/api/endpoints/member.ts
@@ -19,4 +19,6 @@ export const MEMBER_ENDPOINTS = {
     GET_MY_REPORTS: `${API_BASE_URL}/members/me/reports`,
     WITHDRAWAL: `${API_BASE_URL}/members/withdrawal`,
     GET_LOGIN_STATUS: `${API_BASE_URL}/members/me/login-status`,
+    BLOCK: (nickname: string) => `${API_BASE_URL}/members/${encodeURIComponent(nickname)}/block`,
+    GET_MY_BLOCKS: `${API_BASE_URL}/members/me/blocks`,
 };

--- a/src/lib/api/errorMapper.ts
+++ b/src/lib/api/errorMapper.ts
@@ -19,6 +19,12 @@ export const ERROR_MESSAGES: Record<string, string> = {
   BLOCK_402: "차단한 회원이 아닙니다.",
   BLOCK_404: "차단한 사용자입니다.",
   BLOCK_405: "조회가 불가능한 프로필입니다.",
+
+  // Book Story Errors
+  BOOK_STORY_408: "차단 관계가 있는 회원의 책 이야기에는 좋아요를 누를 수 없습니다.",
+
+  // Comment Errors
+  COMMENT_405: "차단 관계가 있는 회원에게는 댓글을 작성할 수 없습니다.",
 };
 
 export function getErrorMessage(code: string): string {

--- a/src/lib/api/errorMapper.ts
+++ b/src/lib/api/errorMapper.ts
@@ -12,6 +12,13 @@ export const ERROR_MESSAGES: Record<string, string> = {
   DUPLICATE_EMAIL: "이미 사용 중인 이메일입니다.",
   INVALID_TOKEN: "유효하지 않은 토큰입니다.",
   EXPIRED_TOKEN: "만료된 토큰입니다.",
+
+  // Block Errors
+  BLOCK_400: "자기 자신을 차단할 수 없습니다.",
+  BLOCK_401: "이미 차단한 회원입니다.",
+  BLOCK_402: "차단한 회원이 아닙니다.",
+  BLOCK_404: "차단한 사용자입니다.",
+  BLOCK_405: "조회가 불가능한 프로필입니다.",
 };
 
 export function getErrorMessage(code: string): string {

--- a/src/lib/api/errors/ApiError.ts
+++ b/src/lib/api/errors/ApiError.ts
@@ -9,3 +9,17 @@ export class ApiError extends Error {
         this.response = response;
     }
 }
+
+export interface ErrorWithCode {
+    code: string;
+    message?: string;
+}
+
+export function hasErrorCode(error: unknown): error is ErrorWithCode {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        typeof (error as Record<string, unknown>).code === "string"
+    );
+}

--- a/src/lib/api/errors/errorMapper.ts
+++ b/src/lib/api/errors/errorMapper.ts
@@ -12,6 +12,10 @@ export const ERROR_MESSAGES: Record<string, string> = {
     DUPLICATE_EMAIL: "이미 사용 중인 이메일입니다.",
     INVALID_TOKEN: "유효하지 않은 토큰입니다.",
     EXPIRED_TOKEN: "만료된 토큰입니다.",
+
+    // Block Errors
+    BLOCK_404: "차단한 사용자입니다.",
+    BLOCK_405: "조회가 불가능한 프로필입니다.",
 };
 
 export function getErrorMessage(code: string): string {

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -1,6 +1,6 @@
 import { apiClient } from "@/lib/api/client";
 import { MEMBER_ENDPOINTS } from "@/lib/api/endpoints/member";
-import { RecommendResponse, UpdateProfileRequest, UpdatePasswordRequest, ProfileResponse, OtherProfileResponse, ReportMemberRequest, FollowListResponse, FollowCountResponse, FindEmailRequest, FindEmailResponse, ReportListResponse, LoginStatusResponse, UpdateEmailRequest } from "@/types/member";
+import { RecommendResponse, UpdateProfileRequest, UpdatePasswordRequest, ProfileResponse, OtherProfileResponse, ReportMemberRequest, FollowListResponse, FollowCountResponse, FindEmailRequest, FindEmailResponse, ReportListResponse, LoginStatusResponse, UpdateEmailRequest, BlockListResponse } from "@/types/member";
 import { ApiResponse } from "@/types/auth";
 
 export const memberService = {
@@ -135,6 +135,30 @@ export const memberService = {
         const response = await apiClient.get<ApiResponse<LoginStatusResponse>>(
             MEMBER_ENDPOINTS.GET_LOGIN_STATUS
         );
+        return response.result!;
+    },
+    blockMember: async (nickname: string): Promise<void> => {
+        const response = await apiClient.post<ApiResponse<unknown>>(
+            MEMBER_ENDPOINTS.BLOCK(nickname)
+        );
+        if (!response.isSuccess) {
+            throw new Error(response.message || "차단에 실패했습니다.");
+        }
+    },
+    unblockMember: async (nickname: string): Promise<void> => {
+        const response = await apiClient.delete<ApiResponse<unknown>>(
+            MEMBER_ENDPOINTS.BLOCK(nickname)
+        );
+        if (!response.isSuccess) {
+            throw new Error(response.message || "차단 해제에 실패했습니다.");
+        }
+    },
+    getBlockedList: async (cursorId?: number): Promise<BlockListResponse> => {
+        const url = new URL(MEMBER_ENDPOINTS.GET_MY_BLOCKS);
+        if (cursorId) {
+            url.searchParams.append("cursorId", cursorId.toString());
+        }
+        const response = await apiClient.get<ApiResponse<BlockListResponse>>(url.toString());
         return response.result!;
     },
 };

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -83,19 +83,31 @@ export const memberService = {
         }
     },
     getFollowerList: async (nickname?: string, cursorId?: number): Promise<FollowListResponse> => {
-        const url = new URL(nickname ? MEMBER_ENDPOINTS.GET_OTHER_FOLLOWERS(nickname) : MEMBER_ENDPOINTS.GET_FOLLOWERS);
+        const endpoint = nickname ? MEMBER_ENDPOINTS.GET_OTHER_FOLLOWERS(nickname) : MEMBER_ENDPOINTS.GET_FOLLOWERS;
+        const params = new URLSearchParams();
         if (cursorId) {
-            url.searchParams.append("cursorId", cursorId.toString());
+            params.append("cursorId", cursorId.toString());
         }
-        const response = await apiClient.get<ApiResponse<FollowListResponse>>(url.toString());
+        const queryString = params.toString();
+        const url = queryString ? `${endpoint}?${queryString}` : endpoint;
+        const response = await apiClient.get<ApiResponse<FollowListResponse>>(url);
+        if (!response.isSuccess) {
+            throw new Error(response.message || "구독자 목록을 불러오는 데 실패했습니다.");
+        }
         return response.result!;
     },
     getFollowingList: async (nickname?: string, cursorId?: number): Promise<FollowListResponse> => {
-        const url = new URL(nickname ? MEMBER_ENDPOINTS.GET_OTHER_FOLLOWINGS(nickname) : MEMBER_ENDPOINTS.GET_FOLLOWINGS);
+        const endpoint = nickname ? MEMBER_ENDPOINTS.GET_OTHER_FOLLOWINGS(nickname) : MEMBER_ENDPOINTS.GET_FOLLOWINGS;
+        const params = new URLSearchParams();
         if (cursorId) {
-            url.searchParams.append("cursorId", cursorId.toString());
+            params.append("cursorId", cursorId.toString());
         }
-        const response = await apiClient.get<ApiResponse<FollowListResponse>>(url.toString());
+        const queryString = params.toString();
+        const url = queryString ? `${endpoint}?${queryString}` : endpoint;
+        const response = await apiClient.get<ApiResponse<FollowListResponse>>(url);
+        if (!response.isSuccess) {
+            throw new Error(response.message || "구독중 목록을 불러오는 데 실패했습니다.");
+        }
         return response.result!;
     },
     getMyFollowCount: async (): Promise<FollowCountResponse> => {
@@ -116,11 +128,17 @@ export const memberService = {
         return response.result!;
     },
     getMyReports: async (cursorId?: number): Promise<ReportListResponse> => {
-        const url = new URL(MEMBER_ENDPOINTS.GET_MY_REPORTS);
+        const endpoint = MEMBER_ENDPOINTS.GET_MY_REPORTS;
+        const params = new URLSearchParams();
         if (cursorId) {
-            url.searchParams.append("cursorId", cursorId.toString());
+            params.append("cursorId", cursorId.toString());
         }
-        const response = await apiClient.get<ApiResponse<ReportListResponse>>(url.toString());
+        const queryString = params.toString();
+        const url = queryString ? `${endpoint}?${queryString}` : endpoint;
+        const response = await apiClient.get<ApiResponse<ReportListResponse>>(url);
+        if (!response.isSuccess) {
+            throw new Error(response.message || "신고 내역을 불러오는 데 실패했습니다.");
+        }
         return response.result!;
     },
     withdraw: async (): Promise<void> => {
@@ -154,11 +172,17 @@ export const memberService = {
         }
     },
     getBlockedList: async (cursorId?: number): Promise<BlockListResponse> => {
-        const url = new URL(MEMBER_ENDPOINTS.GET_MY_BLOCKS);
+        const endpoint = MEMBER_ENDPOINTS.GET_MY_BLOCKS;
+        const params = new URLSearchParams();
         if (cursorId) {
-            url.searchParams.append("cursorId", cursorId.toString());
+            params.append("cursorId", cursorId.toString());
         }
-        const response = await apiClient.get<ApiResponse<BlockListResponse>>(url.toString());
+        const queryString = params.toString();
+        const url = queryString ? `${endpoint}?${queryString}` : endpoint;
+        const response = await apiClient.get<ApiResponse<BlockListResponse>>(url);
+        if (!response.isSuccess) {
+            throw new Error(response.message || "차단 목록을 불러오는 데 실패했습니다.");
+        }
         return response.result!;
     },
 };

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import Cookies from "js-cookie";
 import { User } from "@/types/auth";
+import { useBlockStore } from "@/store/useBlockStore";
 
 interface AuthState {
   user: User | null;
@@ -22,6 +23,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   login: (user) => set({ user, isLoggedIn: true, isLoginModalOpen: false, isInitialized: true }),
   logout: () => {
     Cookies.remove("accessToken");
+    useBlockStore.getState().resetBlocks();
     set({ user: null, isLoggedIn: false, isInitialized: true });
   },
   openLoginModal: () => set({ isLoginModalOpen: true }),

--- a/src/store/useBlockStore.ts
+++ b/src/store/useBlockStore.ts
@@ -1,0 +1,53 @@
+import { create } from "zustand";
+import { memberService } from "@/services/memberService";
+
+interface BlockState {
+  blockedNicknames: Set<string>;
+  isInitialized: boolean;
+  setBlockedNicknames: (nicknames: string[]) => void;
+  addBlockedNickname: (nickname: string) => void;
+  removeBlockedNickname: (nickname: string) => void;
+  isBlocked: (nickname: string) => boolean;
+  initializeBlocks: () => Promise<void>;
+  resetBlocks: () => void;
+}
+
+export const useBlockStore = create<BlockState>((set, get) => ({
+  blockedNicknames: new Set<string>(),
+  isInitialized: false,
+  setBlockedNicknames: (nicknames) => set({ blockedNicknames: new Set(nicknames), isInitialized: true }),
+  addBlockedNickname: (nickname) => set((state) => {
+    const next = new Set(state.blockedNicknames);
+    next.add(nickname);
+    return { blockedNicknames: next };
+  }),
+  removeBlockedNickname: (nickname) => set((state) => {
+    const next = new Set(state.blockedNicknames);
+    next.delete(nickname);
+    return { blockedNicknames: next };
+  }),
+  isBlocked: (nickname) => get().blockedNicknames.has(nickname),
+  initializeBlocks: async () => {
+    if (get().isInitialized) return;
+    try {
+      const allNicknames: string[] = [];
+      let hasNext = true;
+      let cursorId: number | undefined = undefined;
+
+      while (hasNext) {
+        const data = await memberService.getBlockedList(cursorId);
+        allNicknames.push(...data.blocks.map((b) => b.nickname));
+        hasNext = data.hasNext;
+        cursorId = data.nextCursor ?? undefined;
+        if (!data.hasNext || !data.nextCursor) {
+          break;
+        }
+      }
+
+      set({ blockedNicknames: new Set(allNicknames), isInitialized: true });
+    } catch (error) {
+      console.error("Failed to initialize blocked users list:", error);
+    }
+  },
+  resetBlocks: () => set({ blockedNicknames: new Set<string>(), isInitialized: false }),
+}));

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -100,3 +100,15 @@ export interface LoginStatusResponse {
     provider: LoginProvider;
     email: string;
 }
+
+export interface BlockedUser {
+    memberId: string;
+    nickname: string;
+    profileImageUrl: string | null;
+}
+
+export interface BlockListResponse {
+    blocks: BlockedUser[];
+    hasNext: boolean;
+    nextCursor: number | null;
+}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 회원 차단(Block), 해제(Unblock), 차단 관리 목록 조회(GetBlocks) API 연동 및 이에 따른 실시간 캐시 무효화, 예외 에러 대응, 댓글 마스킹 UI 고도화 작업을 진행했습니다.
- **관련 이슈**: #326 (회원 차단 시스템 구축 및 피드/댓글 예외 대응)

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [x] 기타 (설명: 캐시 실시간 정합성 동기화)

### 1. 타입 및 에러 매핑 레이어 (`types/member.ts`, `lib/api/errorMapper.ts`)
- 차단된 회원 정보(`BlockedUser`) 및 목록 응답(`BlockListResponse`) 규격 신규 정의.
- 차단으로 발생할 수 있는 서버 에러 규격에 맞게 매핑 추가:
  - `BLOCK_400`: 자기 자신 차단 불가
  - `BLOCK_401`: 이미 차단한 회원
  - `BLOCK_402`: 차단하지 않은 회원
  - `BLOCK_404`: 차단한 사용자 프로필 접근 예외
  - `BLOCK_405`: 차단 당한 프로필 접근 예외
  - `BOOK_STORY_408`: 차단 관계 내 책 이야기 좋아요 불가 예외
  - `COMMENT_405`: 차단 관계 내 댓글/대댓글 작성 불가 예외

### 2. API & Data 서비스 레이어 (`lib/api/endpoints/member.ts`, `services/memberService.ts`)
- 차단 토글 API(POST/DELETE `/api/members/{nickname}/block`) 및 차단 조회 API(GET `/api/members/me/blocks`) 엔드포인트 연동.
- 커서 기반 페이징 처리가 내장된 `getBlockedList` 및 `blockMember`, `unblockMember` 서비스 추상화 구현.

### 3. React Query 데이터 레이어 (`hooks/queries/useMemberQueries.ts`, `hooks/mutations/useMemberMutations.ts`, `hooks/mutations/useStoryMutations.ts`)
- 무한 스크롤 및 다음 커서 매핑을 갖는 `useBlockedUsersQuery` 훅 신규 구축.
- `useBlockMemberMutation` / `useUnblockMemberMutation` 구현:
  - 차단/해제 성공 시 차단 목록 캐시 무효화(`memberKeys.blocks()`) 연동.
  - **실시간 UI 갱신**: 차단/해제 성공 시 현재 탐색 중인 책이야기 캐시(`storyKeys.all`)를 깜빡임 없이 즉시 만료(`refetchType: 'none'`) 처리하여, 페이지 재접근 시 마스킹 상태가 자동 동기화되도록 조치.
- `useToggleStoryLikeMutation`의 `onError` 내에 `BOOK_STORY_408` 에러 코드가 검출될 시 적절한 토스트 에러 팝업을 표시하도록 분기 처리.

### 4. UI/UX 연동 레이어
- **차단 관리 설정 화면 (`app/(main)/setting/block/page.tsx`)**:
  - Mock 데이터를 100% 제거하고 `useBlockedUsersQuery` 기반 무한 스크롤(Intersection Observer) 구현.
  - 해제 버튼 클릭 시 `useUnblockMemberMutation`을 즉시 유기적으로 연동.
- **프로필 상세 화면 (`ProfileUserInfo.tsx`)**:
  - `handleBlockSubmitLogic` 내의 Mock 딜레이를 제거하고 실제 차단 Mutation 적용.
  - `BLOCK_404`, `BLOCK_405` 예외 발생 시 전용 마스킹 안내 UI로 치환 처리 및 PM/기획 변경 사항 대응을 위한 주석 마킹 추가.
- **책 이야기 상세 화면 (`stories/[id]/page.tsx`)**:
  - 차단 관계 사용자의 게시글 진입으로 인한 로드 에러(`BLOCK_404`/`BLOCK_405`) 발생 시 전용 404 차단 마스킹 템플릿 제공.
- **댓글 섹션 및 목록 화면 (`comment_section_bookcase.tsx`, `comment_list.tsx`, `comment_item.tsx`)**:
  - 서버 마스킹 규격(`nickname === "차단된 사용자입니다"`)에 맞춰 `isBlocked` 판별자 도입.
  - 차단된 사용자의 댓글의 경우 **텍스트 이탤릭/회색 비활성화 스타일** 적용, **프로필 링크 제거(클릭 불가)**, **답글 및 신고 버튼 제외** 처리.
  - 차단 관계 중 댓글/답글 작성 시도 시 발생하는 `COMMENT_405` 에러 토스트 피드백 세부 처리.

### 5. 토스트 노출 개선
- 차단 완료 시 중복으로 호출되던 `showCustomToast` 트랙을 파악하여 `useReportBlockFlow.ts` 측 호출을 제거하고, Mutation의 `onSuccess` 1개 트랙으로 통합 정리하여 단일 토스트만 출력되도록 버그 수정.
- **[참고사항]**: 차단/해제 토스트는 기획 스타일 템플릿을 준수하기 위해 `toast.success` 대신 기존의 `showCustomToast`를 적용했으나, 배경색에 대한 스타일은 현재 프로젝트의 시그니처 톤 유지를 위해 기존 스타일 테두리(`opacity` 및 `#8C7B70/80`) 버전을 유지하도록 반영했습니다.

## 📸 스크린샷 (Screenshots)

## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build` -> Exit code: 0)
- [x] 린트 에러가 없나요? (`pnpm tsc --noEmit` -> 검사 완료)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to block and unblock members
  * Added blocked users list page with infinite scroll pagination

* **UI/UX Improvements**
  * Blocked comments now display with muted, italic styling and are non-interactive
  * Enhanced error messages for blocked relationship scenarios, including when accessing blocked users' stories or attempting to comment on restricted content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmo2025/FE/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->