### PR TITLE
feat: 책 검색 후 책 클릭 시 알라딘 url 연결

### DIFF
--- a/src/app/(main)/books/[id]/BookDetailClient.tsx
+++ b/src/app/(main)/books/[id]/BookDetailClient.tsx
@@ -10,6 +10,7 @@ import { useBookInfiniteStoriesQuery } from "@/hooks/queries/useStoryQueries";
 import { useToggleStoryLikeMutation } from "@/hooks/mutations/useStoryMutations";
 import { useToggleFollowMutation } from "@/hooks/mutations/useMemberMutations";
 import { useAuthAction } from "@/hooks/useAuthAction";
+import { showCustomToast } from "@/utils/toastUtils";
 
 export default function BookDetailClient() {
     const params = useParams();
@@ -76,6 +77,13 @@ export default function BookDetailClient() {
                         onLikeChange={authAction(() => {
                             toggleBookLike(isbn);
                         })}
+                        onCardClick={() => {
+                            if (bookData.link) {
+                                window.open(bookData.link, "_blank", "noopener,noreferrer");
+                            } else {
+                                showCustomToast("구매 링크가 제공되지 않는 도서입니다.");
+                            }
+                        }}
                         onPencilClick={authAction(() => {
                             router.push(`/stories/new?isbn=${isbn}`);
                         })}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 책 상세 페이지(`/books/[id]`) 상단의 책 정보를 나타내는 카드(`SearchBookResult`) 클릭 시, API로 받아온 도서 상세 구매/정보 `link`가 있는 경우 새 탭으로 연결되도록 구현했습니다.
- `link` 정보가 없는 도서의 경우, 카드 클릭 시 기존에 정의되어 있는 공통 커스텀 토스트(`showCustomToast`)를 통해 사용자에게 안내 문구를 제공합니다.
- 관련 이슈: #374

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

**변경 상세:**
- [`src/app/(main)/books/[id]/BookDetailClient.tsx`](file:///Users/shinwookkang/Desktop/CheckMo/FE/src/app/(main)/books/[id]/BookDetailClient.tsx)
  - `showCustomToast` 유틸리티 함수 임포트 추가
  - `SearchBookResult` 컴포넌트의 `onCardClick` prop에 `bookData.link` 유무에 따른 분기 로직 구현
    - `link`가 존재할 때: `window.open(bookData.link, "_blank", "noopener,noreferrer")`를 사용해 새 탭으로 안전하게 이동
    - `link`가 존재하지 않을 때(빈 문자열 등): `showCustomToast("구매 링크가 제공되지 않는 도서입니다.")` 실행

## 📸 스크린샷 (Screenshots)
*(UI 수정 내용이 코드 레벨에서만 반영되었으므로 생략 가능하나, 기기 테스트 시 아래와 같이 나타납니다)*
- **정상 링크 클릭 시:** 도서 판매사/정보 사이트가 새 탭으로 열림
- **빈 링크 클릭 시:** 화면 하단에 `"구매 링크가 제공되지 않는 도서입니다."` 토스트 알림 팝업

## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
  - 실행 결과 `Compiled successfully` 및 static page generation 정상 완료 확인
- [x] 린트 에러가 없나요? (`pnpm lint`)
  - 프로젝트 내에 기존에 존재하던 Type 및 React-hooks 린트 에러 외에, **이번에 수정한 `BookDetailClient.tsx` 파일에서는 어떠한 린트 에러나 경고도 발생하지 않았습니다.**
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

---

### 💡 PR 코멘트 / 리뷰 요약
1. **관심사 분리(SoC) 및 중복 배제(DRY) 만족:** 
   - 기존의 외부 팝업 라이브러리 및 임의의 Toast 컴포넌트를 추가 생성하지 않고, 프로젝트 전반에서 재사용하고 있는 [`utils/toastUtils.tsx`](file:///Users/shinwookkang/Desktop/CheckMo/FE/src/utils/toastUtils.tsx)의 `showCustomToast`를 그대로 활용하였습니다.
2. **보안성(Security):** 
   - `window.open` 호출 시 `noopener,noreferrer`를 설정하여 탭 가로채기(Reverse Tabnabbing) 취약점을 사전에 방지하도록 안전하게 구성했습니다.
3. **UX 개선:** 
   - `onCardClick`에 정상적인 동작(`() => void` 함수)이 매핑될 때만 `SearchBookResult` 내부 스타일 분기를 통해 `cursor-pointer` 및 마우스 오버 그림자(`hover:shadow-lg`)가 정상 작동합니다. 빈 링크일 때도 사용자에게 토스트 알림으로 피드백을 전달하여 모호한 UX를 제거했습니다.