### PR TITLE
feat: 프로필 미완성 회원 분기 처리 및 회원가입 UX·비밀번호 정책 개선

### DIFF
--- a/src/app/(main)/setting/password/PasswordChangePageClient.tsx
+++ b/src/app/(main)/setting/password/PasswordChangePageClient.tsx
@@ -5,6 +5,11 @@ import SettingsDetailLayout from "@/components/base-ui/Settings/SettingsDetailLa
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { useUpdatePasswordMutation } from "@/hooks/mutations/useMemberMutations";
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_VALIDATION_ERROR_MESSAGE,
+  isPasswordValid,
+} from "@/constants/password";
 
 export default function PasswordChangePageClient() {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -24,9 +29,8 @@ export default function PasswordChangePageClient() {
       return;
     }
 
-    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^&*]).{6,12}$/;
-    if (!passwordRegex.test(newPassword)) {
-      toast.error("비밀번호는 영문자, 특수문자를 포함하여 6~12자여야 합니다.");
+    if (!isPasswordValid(newPassword)) {
+      toast.error(PASSWORD_VALIDATION_ERROR_MESSAGE);
       return;
     }
 
@@ -39,9 +43,10 @@ export default function PasswordChangePageClient() {
           setNewPassword("");
           setConfirmPassword("");
         },
-        onError: (error: any) => {
+        onError: (error: unknown) => {
           // Check backend error response format if available, otherwise generic
-          toast.error(error.message || "비밀번호 변경에 실패했습니다. 올바른 기존 비밀번호인지 확인하세요.");
+          const errorMessage = error instanceof Error ? error.message : null;
+          toast.error(errorMessage || "비밀번호 변경에 실패했습니다. 올바른 기존 비밀번호인지 확인하세요.");
         },
       }
     );
@@ -72,6 +77,7 @@ export default function PasswordChangePageClient() {
               type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
+              maxLength={PASSWORD_MAX_LENGTH}
             />
             {/* 비밀번호 확인 인풋 */}
             <div className={inputContainerClass}>
@@ -81,6 +87,7 @@ export default function PasswordChangePageClient() {
                 placeholder="비밀번호 확인"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
+                maxLength={PASSWORD_MAX_LENGTH}
               />
             </div>
           </div>

--- a/src/app/(public)/signup/[step]/SignupStepPageClient.tsx
+++ b/src/app/(public)/signup/[step]/SignupStepPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import TermsAgreement from "@/components/base-ui/Join/steps/TermsAgreement/TermsAgreement";
 import EmailVerification from "@/components/base-ui/Join/steps/EmailVerification/EmailVerification";
@@ -8,8 +8,13 @@ import PasswordEntry from "@/components/base-ui/Join/steps/PasswordEntry/Passwor
 import ProfileSetup from "@/components/base-ui/Join/steps/ProfileSetup/ProfileSetup";
 import ProfileImage from "@/components/base-ui/Join/steps/ProfileImage/ProfileImage";
 import SignupComplete from "@/components/base-ui/Join/steps/SignupComplete/SignupComplete";
+import ConfirmModal from "@/components/common/ConfirmModal";
 import { useSignup } from "@/contexts/SignupContext";
 import { useAuthStore } from "@/store/useAuthStore";
+import {
+    isProfileIncomplete,
+    PROFILE_COMPLETION_ROUTE,
+} from "@/utils/profileCompletion";
 
 export default function SignupStepPageClient() {
     const params = useParams();
@@ -18,6 +23,11 @@ export default function SignupStepPageClient() {
     const step = params.step as string;
     const { isSocial, setIsSocial, setEmail, email } = useSignup();
     const { user, isLoggedIn } = useAuthStore();
+    const [hasDismissedProfileNotice, setHasDismissedProfileNotice] = useState(false);
+    const isProfileNoticeOpen =
+        step === "profile" &&
+        searchParams.get("profileRequired") === "true" &&
+        !hasDismissedProfileNotice;
 
     useEffect(() => {
         const isSocialParam = searchParams.get("isSocial");
@@ -29,8 +39,8 @@ export default function SignupStepPageClient() {
             return;
         }
 
-        const storeIsSocial = isLoggedIn && user && !user.nickname;
-        const shouldBeSocial = urlIsSocial || storeIsSocial;
+        const needsProfileCompletion = isLoggedIn && isProfileIncomplete(user);
+        const shouldBeSocial = urlIsSocial || needsProfileCompletion;
 
         if (shouldBeSocial) {
             if (!isSocial) {
@@ -42,8 +52,8 @@ export default function SignupStepPageClient() {
                 setEmail(newEmail);
             }
 
-            if (step === "email" || step === "password") {
-                router.replace(`/signup/profile?isSocial=true`);
+            if (step === "terms" || step === "email" || step === "password") {
+                router.replace(PROFILE_COMPLETION_ROUTE);
             }
         }
     }, [searchParams, user, isLoggedIn, isSocial, email, setIsSocial, setEmail, step, router]);
@@ -72,5 +82,15 @@ export default function SignupStepPageClient() {
         return null;
     }
 
-    return <>{currentStep}</>;
+    return (
+        <>
+            {currentStep}
+            <ConfirmModal
+                isOpen={isProfileNoticeOpen}
+                message="프로필을 완성해주세요"
+                onConfirm={() => setHasDismissedProfileNotice(true)}
+                onCancel={() => setHasDismissedProfileNotice(true)}
+            />
+        </>
+    );
 }

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,16 +1,62 @@
 "use client";
 
 import { useEffect } from "react";
-import Cookies from "js-cookie";
+import { usePathname, useRouter } from "next/navigation";
 import * as Sentry from "@sentry/nextjs";
+import ConfirmModal from "@/components/common/ConfirmModal";
 import { useAuthStore } from "@/store/useAuthStore";
 import { authService } from "@/services/authService";
+import {
+  PROFILE_COMPLETION_BASE_ROUTE,
+  isProfileCompletionPath,
+  isProfileIncompleteError,
+  isProfileIncomplete,
+} from "@/utils/profileCompletion";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const { login, logout, setInitialized } = useAuthStore();
+  const { login, logout, setInitialized, user, isLoggedIn, isInitialized } = useAuthStore();
+  const pathname = usePathname();
+  const router = useRouter();
+  const shouldRequireProfileCompletion =
+    isInitialized &&
+    isLoggedIn &&
+    isProfileIncomplete(user) &&
+    !isProfileCompletionPath(pathname) &&
+    !pathname?.startsWith("/admin");
 
   useEffect(() => {
     const initAuth = async () => {
+      const setProfileIncompleteUser = (email: string = "") => {
+        login({
+          email,
+          profileCompleted: false,
+        });
+
+        if (email) {
+          Sentry.setUser({
+            id: email,
+            email,
+          });
+        } else {
+          Sentry.setUser(null);
+        }
+      };
+
+      const restoreProfileIncompleteUser = async () => {
+        try {
+          const loginStatusResponse = await authService.getLoginStatus();
+
+          if (loginStatusResponse.isSuccess && loginStatusResponse.result) {
+            setProfileIncompleteUser(loginStatusResponse.result.email || "");
+            return;
+          }
+        } catch {
+          // /members/me 403 itself means the session exists but the profile is incomplete.
+        }
+
+        setProfileIncompleteUser();
+      };
+
       try {
         const response = await authService.getProfile();
         if (response.isSuccess && response.result) {
@@ -28,7 +74,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           Sentry.setUser(null);
         }
       } catch (error) {
-        // 401 에러 등은 apiClient에서 이미 처리하지만, 여기서도 세션을 안전하게 초기화합니다.
+        if (isProfileIncompleteError(error)) {
+          await restoreProfileIncompleteUser();
+          return;
+        }
+
         logout();
         Sentry.setUser(null);
       } finally {
@@ -39,5 +89,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     initAuth();
   }, [login, logout, setInitialized]);
 
-  return <>{children}</>;
+  const goToProfileCompletion = () => {
+    router.replace(PROFILE_COMPLETION_BASE_ROUTE);
+  };
+
+  return (
+    <>
+      {children}
+      <ConfirmModal
+        isOpen={shouldRequireProfileCompletion}
+        message="프로필을 완성해주세요"
+        onConfirm={goToProfileCompletion}
+        onCancel={goToProfileCompletion}
+      />
+    </>
+  );
 }

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -93,9 +93,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     router.replace(PROFILE_COMPLETION_BASE_ROUTE);
   };
 
-  const handleCancelGate = () => {
-    // 취소(딤 클릭/ESC 포함) → 로그인 상태 해제 후 홈으로
-    logout();
+  const handleCancelGate = async () => {
+    // 취소(딤 클릭/ESC 포함) → 서버 세션까지 로그아웃 후 홈으로
+    // authService.logout()이 BE /auth/logout 호출 + 클라이언트 상태 정리를 모두 수행
+    await authService.logout();
     Sentry.setUser(null);
     router.replace("/");
   };

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -93,6 +93,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     router.replace(PROFILE_COMPLETION_BASE_ROUTE);
   };
 
+  const handleCancelGate = () => {
+    // 취소(딤 클릭/ESC 포함) → 로그인 상태 해제 후 홈으로
+    logout();
+    Sentry.setUser(null);
+    router.replace("/");
+  };
+
   return (
     <>
       {children}
@@ -100,7 +107,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isOpen={shouldRequireProfileCompletion}
         message="프로필을 완성해주세요"
         onConfirm={goToProfileCompletion}
-        onCancel={goToProfileCompletion}
+        onCancel={handleCancelGate}
+        closeOnConfirm={false}
       />
     </>
   );

--- a/src/components/base-ui/Join/steps/PasswordEntry/PasswordEntry.tsx
+++ b/src/components/base-ui/Join/steps/PasswordEntry/PasswordEntry.tsx
@@ -6,6 +6,11 @@ import JoinButton from "@/components/base-ui/Join/JoinButton";
 import JoinInput from "@/components/base-ui/Join/JoinInput";
 import { useSignup } from "@/contexts/SignupContext";
 import { authService } from "@/services/authService";
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_REQUIREMENTS_MESSAGE,
+  isPasswordValid,
+} from "@/constants/password";
 
 interface PasswordEntryProps {
   onNext: () => void;
@@ -15,10 +20,8 @@ const PasswordEntry: React.FC<PasswordEntryProps> = ({ onNext }) => {
   const { email, password, setPassword, confirmPassword, setConfirmPassword, showToast } = useSignup();
   const [isLoading, setIsLoading] = React.useState(false);
 
-  // 유효성 검사: 6-12자, 영어 최소 1자, 특수문자 최소 1자 포함
-  const passwordRegex = /^(?=.*[A-Za-z])(?=.*[!@#$%^&*()_+={}\[\]:;"'<>,.?/-]).{6,12}$/;
   const isMatch =
-    passwordRegex.test(password) && password === confirmPassword;
+    isPasswordValid(password) && password === confirmPassword;
 
   const handleNext = async () => {
     if (!isMatch || isLoading) return;
@@ -44,12 +47,12 @@ const PasswordEntry: React.FC<PasswordEntryProps> = ({ onNext }) => {
           {/* Password Input */}
           <JoinInput
             label="비밀번호"
-            description="비밀번호는 6-12자, 영어 최소 1자 이상, 특수문자 최소 1자 이상"
+            description={PASSWORD_REQUIREMENTS_MESSAGE}
             type="password"
             placeholder="비밀번호"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            maxLength={12}
+            maxLength={PASSWORD_MAX_LENGTH}
             className="border-Subbrown-4 placeholder-Gray-3 bg-white"
           />
 
@@ -59,7 +62,7 @@ const PasswordEntry: React.FC<PasswordEntryProps> = ({ onNext }) => {
             placeholder="비밀번호 확인"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            maxLength={12}
+            maxLength={PASSWORD_MAX_LENGTH}
             className="border-Subbrown-4 placeholder-Gray-3 bg-white"
           />
         </div>

--- a/src/components/base-ui/Join/steps/PasswordEntry/usePasswordEntry.ts
+++ b/src/components/base-ui/Join/steps/PasswordEntry/usePasswordEntry.ts
@@ -1,14 +1,12 @@
 import { useState } from "react";
+import { isPasswordValid } from "@/constants/password";
 
 export const usePasswordEntry = () => {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
-  // 6-12자, 영문 최소 1자, 특수문자 최소 1자
-  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^&*]).{6,12}$/;
-
   // Derived State (No useEffect)
-  const isComplexityValid = passwordRegex.test(password);
+  const isComplexityValid = isPasswordValid(password);
   const isMatch = password === confirmPassword;
   const isValid =
     isComplexityValid &&

--- a/src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts
+++ b/src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts
@@ -3,9 +3,11 @@ import { useSignup } from "@/contexts/SignupContext";
 import { authService } from "@/services/authService";
 import { CATEGORY_MAP } from "@/constants/categories";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export const useProfileImage = () => {
   const {
+    email,
     nickname,
     name,
     phone: phoneNumber,
@@ -18,6 +20,8 @@ export const useProfileImage = () => {
     setIsProfileImageSet,
     showToast,
   } = useSignup();
+  const login = useAuthStore((state) => state.login);
+  const currentUser = useAuthStore((state) => state.user);
 
   const [isLoading, setIsLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -90,6 +94,35 @@ export const useProfileImage = () => {
         profileImageUrl: finalImageUrl,
         categories,
       });
+
+      const fallbackEmail = currentUser?.email || email;
+      const fallbackUser = {
+        email: fallbackEmail,
+        nickname,
+        name,
+        phoneNumber,
+        description,
+        profileImageUrl: finalImageUrl,
+        categories,
+        profileCompleted: true,
+      };
+
+      try {
+        const profileResponse = await authService.getProfile();
+
+        if (profileResponse.isSuccess && profileResponse.result) {
+          login({
+            ...profileResponse.result,
+            email: profileResponse.result.email || fallbackEmail,
+            profileCompleted: true,
+          });
+        } else {
+          login(fallbackUser);
+        }
+      } catch (profileError) {
+        console.error("Profile fetch failed after profile creation:", profileError);
+        login(fallbackUser);
+      }
 
       onSuccess?.();
     } catch (error: unknown) {

--- a/src/components/base-ui/Login/LoginModal.tsx
+++ b/src/components/base-ui/Login/LoginModal.tsx
@@ -33,6 +33,7 @@ export default function LoginModal({ onClose, onSignUp }: Props) {
   useScrollLock();
 
   const handleSignUp = () => {
+    onClose();
     if (onSignUp) onSignUp();
     router.push("/signup");
   };

--- a/src/components/base-ui/Login/hooks/useLoginForm.tsx
+++ b/src/components/base-ui/Login/hooks/useLoginForm.tsx
@@ -3,9 +3,13 @@ import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/store/useAuthStore";
-import { LoginForm } from "@/types/auth";
+import { LoginForm, User } from "@/types/auth";
 import { authService } from "@/services/authService";
 import { ApiError } from "@/lib/api/errors";
+import {
+  isProfileIncomplete,
+  PROFILE_COMPLETION_ROUTE,
+} from "@/utils/profileCompletion";
 
 export default function useLoginForm(onSuccess?: () => void) {
   const router = useRouter();
@@ -45,7 +49,12 @@ export default function useLoginForm(onSuccess?: () => void) {
 
     try {
       // Service Layer 호출
-      const loginData = await authService.login(form);
+      await authService.login(form);
+
+      let loggedInUser: User = {
+        email: form.identifier,
+        profileCompleted: false,
+      };
 
       // 상세 프로필 정보 가져오기
       try {
@@ -53,18 +62,19 @@ export default function useLoginForm(onSuccess?: () => void) {
 
         if (profileResponse.isSuccess && profileResponse.result) {
           // 전역 상태에 상세 정보 저장
-          login({
+          loggedInUser = {
             ...profileResponse.result,
             email: form.identifier
-          });
+          };
+          login(loggedInUser);
         } else {
           // 프로필 조회 실패 시에도 최소한의 정보로 로그인 처리
-          login({ email: form.identifier });
+          login(loggedInUser);
         }
       } catch (profileError) {
         console.error("Profile fetch failed during login:", profileError);
         // 프로필 로드 실패해도 로그인은 성공한 상태이므로 최소 정보로 진행
-        login({ email: form.identifier });
+        login(loggedInUser);
       }
 
       // 2. Navigation & UI Feedback
@@ -72,7 +82,7 @@ export default function useLoginForm(onSuccess?: () => void) {
       router.refresh();
       toast.success("로그인에 성공했습니다!");
       if (onSuccess) onSuccess();
-      router.push("/");
+      router.push(isProfileIncomplete(loggedInUser) ? PROFILE_COMPLETION_ROUTE : "/");
     } catch (error) {
       if (error instanceof ApiError) {
         // 비즈니스 에러 (예: 비밀번호 불일치)는 인라인 에러로 처리

--- a/src/components/base-ui/Login/hooks/useLoginForm.tsx
+++ b/src/components/base-ui/Login/hooks/useLoginForm.tsx
@@ -53,8 +53,8 @@ export default function useLoginForm(onSuccess?: () => void) {
 
       let loggedInUser: User = {
         email: form.identifier,
-        profileCompleted: false,
       };
+      let profileResolved = false;
 
       // 상세 프로필 정보 가져오기
       try {
@@ -66,14 +66,13 @@ export default function useLoginForm(onSuccess?: () => void) {
             ...profileResponse.result,
             email: form.identifier
           };
-          login(loggedInUser);
-        } else {
-          // 프로필 조회 실패 시에도 최소한의 정보로 로그인 처리
-          login(loggedInUser);
+          profileResolved = true;
         }
+
+        login(loggedInUser);
       } catch (profileError) {
         console.error("Profile fetch failed during login:", profileError);
-        // 프로필 로드 실패해도 로그인은 성공한 상태이므로 최소 정보로 진행
+        // 프로필 로드 실패 시 프로필 완성 여부를 단정하지 않고 최소 정보로 로그인 처리
         login(loggedInUser);
       }
 
@@ -82,7 +81,12 @@ export default function useLoginForm(onSuccess?: () => void) {
       router.refresh();
       toast.success("로그인에 성공했습니다!");
       if (onSuccess) onSuccess();
-      router.push(isProfileIncomplete(loggedInUser) ? PROFILE_COMPLETION_ROUTE : "/");
+      // 프로필을 확실히 조회했고 그게 미완성일 때만 완성 페이지로, 그 외(실패/불명)는 홈으로
+      router.push(
+        profileResolved && isProfileIncomplete(loggedInUser)
+          ? PROFILE_COMPLETION_ROUTE
+          : "/"
+      );
     } catch (error) {
       if (error instanceof ApiError) {
         // 비즈니스 에러 (예: 비밀번호 불일치)는 인라인 에러로 처리

--- a/src/components/base-ui/Settings/SettingsInputGroup.tsx
+++ b/src/components/base-ui/Settings/SettingsInputGroup.tsx
@@ -5,6 +5,7 @@ type Props = {
   type?: "text" | "password" | "email";
   value?: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  maxLength?: number;
 };
 
 export default function SettingsInputGroup({
@@ -13,6 +14,7 @@ export default function SettingsInputGroup({
   type = "text",
   value,
   onChange,
+  maxLength,
 }: Props) {
   return (
     <div className="flex w-full flex-col items-start gap-[12px] self-stretch">
@@ -27,6 +29,7 @@ export default function SettingsInputGroup({
           placeholder={placeholder}
           value={value || ""}
           onChange={onChange}
+          maxLength={maxLength}
         />
       </div>
     </div>

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -8,9 +8,10 @@ type ConfirmModalProps = {
     message: string;
     onConfirm: () => void;
     onCancel: () => void;
+    closeOnConfirm?: boolean;
 };
 
-export default function ConfirmModal({ isOpen, message, onConfirm, onCancel }: ConfirmModalProps) {
+export default function ConfirmModal({ isOpen, message, onConfirm, onCancel, closeOnConfirm = true }: ConfirmModalProps) {
     useScrollLock(isOpen);
 
     useEffect(() => {
@@ -58,7 +59,7 @@ export default function ConfirmModal({ isOpen, message, onConfirm, onCancel }: C
                             type="button"
                             onClick={() => {
                                 onConfirm();
-                                onCancel();
+                                if (closeOnConfirm) onCancel();
                             }}
                             className="flex-1 h-[48px] rounded-lg bg-primary-3 text-White body_1_2 hover:bg-primary-3/90 transition-colors cursor-pointer"
                         >

--- a/src/constants/password.ts
+++ b/src/constants/password.ts
@@ -1,0 +1,12 @@
+export const PASSWORD_MIN_LENGTH = 6;
+export const PASSWORD_MAX_LENGTH = 24;
+
+export const PASSWORD_REQUIREMENTS_MESSAGE =
+  `비밀번호는 ${PASSWORD_MIN_LENGTH}-${PASSWORD_MAX_LENGTH}자, 영어 최소 1자 이상, 특수문자 최소 1자 이상`;
+
+export const PASSWORD_VALIDATION_ERROR_MESSAGE =
+  `비밀번호는 영문자, 특수문자를 포함하여 ${PASSWORD_MIN_LENGTH}~${PASSWORD_MAX_LENGTH}자여야 합니다.`;
+
+export const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*[!@#$%^&*()_+={}\[\]:;"'<>,.?/-]).{6,24}$/;
+
+export const isPasswordValid = (password: string) => PASSWORD_REGEX.test(password);

--- a/src/lib/api/admin/endpoints/stories.ts
+++ b/src/lib/api/admin/endpoints/stories.ts
@@ -1,15 +1,15 @@
-const API_BASE_URL = "https://api.checkmo.co.kr";
+const API_BASE_URL = "https://api.checkmo.co.kr/api/v1";
 
 export const ADMIN_STORIES = {
   list: (page = 1, keyword = "") =>
-    `${API_BASE_URL}/api/admin/book-stories?page=${page}&keyword=${encodeURIComponent(keyword)}`,
+    `${API_BASE_URL}/admin/book-stories?page=${page}&keyword=${encodeURIComponent(keyword)}`,
 
   detail: (bookStoryId: number) =>
-    `${API_BASE_URL}/api/admin/book-stories/${bookStoryId}`,
+    `${API_BASE_URL}/admin/book-stories/${bookStoryId}`,
 
   delete: (bookStoryId: number) =>
-    `${API_BASE_URL}/api/admin/book-stories/${bookStoryId}`,
+    `${API_BASE_URL}/admin/book-stories/${bookStoryId}`,
 
   deleteComment: (bookStoryId: number, commentId: number) =>
-    `${API_BASE_URL}/api/admin/book-stories/${bookStoryId}/comments/${commentId}`,
+    `${API_BASE_URL}/admin/book-stories/${bookStoryId}/comments/${commentId}`,
 };

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -1,5 +1,5 @@
 export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "https://api.checkmo.co.kr/api";
+  process.env.NEXT_PUBLIC_API_URL || "https://api.checkmo.co.kr/api/v1";
 
 export const AUTH_ENDPOINTS = {
   LOGIN: `${API_BASE_URL}/auth/login`,

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -10,6 +10,7 @@ export const AUTH_ENDPOINTS = {
   ADDITIONAL_INFO: `${API_BASE_URL}/members/additional-info`,
   CHECK_NICKNAME: `${API_BASE_URL}/members/check-nickname`,
   PROFILE: `${API_BASE_URL}/members/me`,
+  LOGIN_STATUS: `${API_BASE_URL}/members/me/login-status`,
   IMAGE_UPLOAD: (type: string) => `${API_BASE_URL}/image/${type}/upload-url`,
   TEMP_PASSWORD: `${API_BASE_URL}/auth/temp-password`,
 };

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "@/lib/api/client";
-import { AUTH_ENDPOINTS, API_BASE_URL } from "@/lib/api/endpoints";
+import { AUTH_ENDPOINTS } from "@/lib/api/endpoints";
 import { useAuthStore } from "@/store/useAuthStore";
 import {
   LoginForm,
@@ -10,6 +10,7 @@ import {
   SignupForm,
   User
 } from "@/types/auth";
+import { LoginStatusResponse } from "@/types/member";
 
 export const authService = {
   login: async (data: LoginForm): Promise<LoginResponse> => {
@@ -46,6 +47,13 @@ export const authService = {
     return await apiClient.get<ApiResponse<User>>(AUTH_ENDPOINTS.PROFILE, {
       silentAuthError: true,
     });
+  },
+
+  getLoginStatus: async (): Promise<ApiResponse<LoginStatusResponse>> => {
+    return await apiClient.get<ApiResponse<LoginStatusResponse>>(
+      AUTH_ENDPOINTS.LOGIN_STATUS,
+      { silentAuthError: true }
+    );
   },
 
   getPresignedUrl: async (type: "PROFILE" | "CLUB" | "NOTICE", fileName: string, contentType: string): Promise<ApiResponse<{ presignedUrl: string; imageUrl: string }>> => {
@@ -88,4 +96,3 @@ export const authService = {
     );
   },
 };
-

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -99,6 +99,7 @@ export type LoginProvider = "LOCAL" | "GOOGLE" | "KAKAO" | "NAVER";
 export interface LoginStatusResponse {
     provider: LoginProvider;
     email: string;
+    admin?: boolean;
 }
 
 export interface BlockedUser {

--- a/src/utils/profileCompletion.ts
+++ b/src/utils/profileCompletion.ts
@@ -1,0 +1,45 @@
+import { User } from "@/types/auth";
+
+export const PROFILE_COMPLETION_BASE_ROUTE = "/signup/profile?isSocial=true";
+export const PROFILE_COMPLETION_ROUTE = `${PROFILE_COMPLETION_BASE_ROUTE}&profileRequired=true`;
+
+const PROFILE_COMPLETION_PATHS = new Set([
+  "/signup/profile",
+  "/signup/profile-image",
+]);
+
+export const isProfileCompletionPath = (pathname: string | null) => {
+  if (!pathname) return false;
+  return PROFILE_COMPLETION_PATHS.has(pathname);
+};
+
+export const isProfileIncomplete = (user: User | null | undefined) => {
+  if (!user) return false;
+
+  if (typeof user.profileCompleted === "boolean") {
+    return !user.profileCompleted;
+  }
+
+  return !user.nickname;
+};
+
+export const isProfileIncompleteError = (error: unknown) => {
+  if (!(error instanceof Error)) return false;
+
+  const errorWithMeta = error as Error & {
+    code?: string;
+    response?: {
+      code?: string;
+      message?: string;
+    };
+  };
+
+  const code = errorWithMeta.code || errorWithMeta.response?.code || "";
+  const message = error.message || errorWithMeta.response?.message || "";
+
+  return (
+    code === "HTTP403" ||
+    message.includes("프로필이 완성되지 않은 회원") ||
+    message.includes("프로필을 완성")
+  );
+};


### PR DESCRIPTION
## 📝 개요 (Overview)
세션(토큰)은 존재하지만 프로필을 완성하지 않은 회원을 **로그아웃시키지 않고 프로필 완성 단계로 유도**하도록 인증 흐름을 개선했습니다. 더불어 로그인 모달 전환 UX와 비밀번호 정책(최대 길이 확대)을 정리했습니다.

## 🔗 관련 이슈 (Related Issue)
- close #381

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

### 상세 내용
**1. 프로필 미완성 분기 처리 (핵심)**
- `utils/profileCompletion.ts` 추가: 프로필 미완성 판별 / 에러 감지(`HTTP403`, "프로필이 완성되지 않은 회원") 공통 유틸
- `AuthProvider`: 앱 진입 시 `getProfile()`가 프로필 미완성 에러를 반환하면 로그아웃 대신 미완성 상태로 세션 유지(`/members/me/login-status`로 확인) 후 "프로필을 완성해주세요" 모달로 완성 페이지 유도
- `useLoginForm`: 로그인 후 프로필 미완성이면 홈(`/`) 대신 프로필 완성 경로로 이동
- `SignupStepPageClient`: 로그인 + 미완성 사용자를 social 플로우로 처리, terms/email/password 단계 진입 시 프로필 완성으로 redirect
- `authService.getLoginStatus()` / `LOGIN_STATUS` 엔드포인트 / `LoginStatusResponse` 타입 추가
- `useProfileImage`: 프로필 생성 완료 후 전역 상태를 `profileCompleted: true`로 갱신

**2. 로그인 모달 UX**
- `LoginModal`: 회원가입으로 이동 시 모달을 먼저 닫도록 `onClose()` 추가 (모달이 회원가입 페이지에 남던 문제 해결)

**3. 비밀번호 정책 정리 (리팩토링)**
- `constants/password.ts` 추가: 정규식·길이·메시지 중앙화, 최대 길이 **12 → 24자** 확대 (BE 정책과 동기화)
- `PasswordEntry` / `usePasswordEntry` / `PasswordChangePageClient` / `SettingsInputGroup`: 인라인 정규식 제거 후 공통 상수·`isPasswordValid()` 사용, `maxLength` prop 반영

## 📸 스크린샷 (Screenshots)
(프로필 완성 유도 모달 / 로그인·회원가입 흐름 스크린샷 첨부 예정)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?

> ℹ️ 최신 `main`(v1 API prefix 적용본) 머지 반영됨.
