### PR TITLE
refactor: s3 서버 통신 코드 리팩토링

### DIFF
--- a/src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts
+++ b/src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useSignup } from "@/contexts/SignupContext";
+import { imageService } from "@/services/imageService";
 import { authService } from "@/services/authService";
 import { CATEGORY_MAP } from "@/constants/categories";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
@@ -63,21 +64,7 @@ export const useProfileImage = () => {
 
       // 1. If a new image is selected, upload to S3 using Presigned URL
       if (selectedFile) {
-        const presignedResponse = await authService.getPresignedUrl(
-          "PROFILE",
-          selectedFile.name,
-          selectedFile.type
-        );
-
-        if (presignedResponse.isSuccess && presignedResponse.result) {
-          const { presignedUrl, imageUrl } = presignedResponse.result;
-          await authService.uploadToS3(presignedUrl, selectedFile);
-          finalImageUrl = imageUrl;
-        } else {
-          showToast(presignedResponse.message || "이미지 업로드 준비 중 오류가 발생했습니다.");
-          setIsLoading(false);
-          return;
-        }
+        finalImageUrl = await imageService.uploadProfileImage(selectedFile);
       } else if (imgUrl && !imgUrl.startsWith("blob:")) {
         // Includes uploaded S3 URL or default image path (e.g. /profile2.svg)
         finalImageUrl = imgUrl;

--- a/src/hooks/mutations/useMemberMutations.ts
+++ b/src/hooks/mutations/useMemberMutations.ts
@@ -3,6 +3,7 @@ import { memberService } from "@/services/memberService";
 import { toast } from "react-hot-toast";
 import { showCustomToast } from "@/utils/toastUtils";
 import { authService } from "@/services/authService";
+import { imageService } from "@/services/imageService";
 import { useAuthStore } from "@/store/useAuthStore";
 import { ReportMemberRequest, FollowListResponse } from "@/types/member";
 import { memberKeys } from "../queries/useMemberQueries";
@@ -25,16 +26,7 @@ export const useUpdateProfileMutation = () => {
 
             // 1. Image Upload (If file is selected)
             if (payload.profileImageFile) {
-                // Assume default mime if not present
-                const contentType = payload.profileImageFile.type || "image/jpeg";
-                // Get Pre-signed URL
-                const presignedRes = await authService.getPresignedUrl("PROFILE", payload.profileImageFile.name, contentType);
-
-                // Upload to S3
-                await authService.uploadToS3(presignedRes.result!.presignedUrl, payload.profileImageFile);
-
-                // Use the returned image URL for update
-                imgUrl = presignedRes.result!.imageUrl;
+                imgUrl = await imageService.uploadProfileImage(payload.profileImageFile);
             } else if (payload.currentProfileImageUrl && payload.currentProfileImageUrl.startsWith("blob:")) {
                 // In case blob URL leaked without file, though shouldn't happen, clear it
                 imgUrl = undefined;

--- a/src/lib/api/admin/endpoints/image.ts
+++ b/src/lib/api/admin/endpoints/image.ts
@@ -1,7 +1,2 @@
-import { API_BASE_URL } from "../../endpoints/base";
-
-export type ImageUploadType = "PROFILE" | "CLUB" | "NOTICE";
-
-export const IMAGE = {
-  uploadUrl: (type: ImageUploadType) => `${API_BASE_URL}/image/${type}/upload-url`,
-} as const;
+export { IMAGE } from "../../endpoints/Image";
+export type { ImageUploadType } from "../../endpoints/Image";

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -11,6 +11,5 @@ export const AUTH_ENDPOINTS = {
   CHECK_NICKNAME: `${API_BASE_URL}/members/check-nickname`,
   PROFILE: `${API_BASE_URL}/members/me`,
   LOGIN_STATUS: `${API_BASE_URL}/members/me/login-status`,
-  IMAGE_UPLOAD: (type: string) => `${API_BASE_URL}/image/${type}/upload-url`,
   TEMP_PASSWORD: `${API_BASE_URL}/auth/temp-password`,
 };

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -56,27 +56,6 @@ export const authService = {
     );
   },
 
-  getPresignedUrl: async (type: "PROFILE" | "CLUB" | "NOTICE", fileName: string, contentType: string): Promise<ApiResponse<{ presignedUrl: string; imageUrl: string }>> => {
-    return await apiClient.post<ApiResponse<{ presignedUrl: string; imageUrl: string }>>(
-      AUTH_ENDPOINTS.IMAGE_UPLOAD(type),
-      { originalFileName: fileName, contentType }
-    );
-  },
-
-  uploadToS3: async (presignedUrl: string, file: File): Promise<void> => {
-    const response = await fetch(presignedUrl, {
-      method: "PUT",
-      body: file,
-      headers: {
-        "Content-Type": file.type,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error("S3 upload failed");
-    }
-  },
-
   logout: async () => {
     try {
       await apiClient.post(AUTH_ENDPOINTS.LOGOUT);

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -31,11 +31,11 @@ export const imageService = {
   getUploadUrl: (type: ImageUploadType, body: PresignedRequest) =>
     apiClient.post<ApiResponse<PresignedResult>>(IMAGE.uploadUrl(type), body),
 
-  // ✅ create 페이지에서 쓰는 "CLUB 업로드 한방"
-  uploadClubImage: async (file: File) => {
+  // 이미지 업로드 공통 헬퍼: presigned URL 발급 → S3 PUT → imageUrl 반환
+  uploadImage: async (type: ImageUploadType, file: File): Promise<string> => {
     const contentType = file.type || "application/octet-stream";
 
-    const presigned = await imageService.getUploadUrl("CLUB", {
+    const presigned = await imageService.getUploadUrl(type, {
       originalFileName: file.name,
       contentType,
     });
@@ -45,4 +45,10 @@ export const imageService = {
     await putToPresignedUrl(presignedUrl, file, contentType);
     return imageUrl;
   },
+
+  // PROFILE 이미지 업로드
+  uploadProfileImage: (file: File) => imageService.uploadImage("PROFILE", file),
+
+  // CLUB 이미지 업로드
+  uploadClubImage: (file: File) => imageService.uploadImage("CLUB", file),
 };


### PR DESCRIPTION
## 📌 개요 (Summary)

이미지 업로드 로직 분산 및 엔드포인트 중복 문제를 리팩토링

- 관련 이슈: #390

### 배경

`authService`에 이미지 인프라 로직(`getPresignedUrl`, `uploadToS3`)이 혼재되어 SoC(관심사 분리) 원칙을 위반하고 있었으며,
동일한 presigned URL 발급 → S3 PUT 패턴이 `authService` / `imageService` 두 곳에 중복 구현되어 있었습니다. 또한 `/image/{type}/upload-url` 엔드포인트 경로가 `endpoints.ts`, `endpoints/Image.ts`, `admin/endpoints/image.ts` 3곳에 중복 정의되어 있었습니다.

---

## 🛠️ 변경 사항 (Changes)

- [x] 코드 리팩토링

### 변경 파일 (6개, +15 / -57줄)

#### `src/lib/api/admin/endpoints/image.ts`
- `ImageUploadType`, `IMAGE` 상수 중복 정의 제거
- 단일 진실 공급원인 `lib/api/endpoints/Image.ts`에서 re-export 방식으로 통합

#### `src/lib/api/endpoints.ts`
- `AUTH_ENDPOINTS`에서 이미지 관련 항목 `IMAGE_UPLOAD` 제거
- 인증/회원 관련 경로만 남도록 정리

#### `src/services/imageService.ts`
- 타입별 하드코딩된 `uploadClubImage`를 내부 공통 헬퍼 `uploadImage(type, file)`로 추출
- `uploadProfileImage(file)` 편의 메서드 추가
- `uploadClubImage`는 기존 시그니처(`(file: File) => Promise<string>`) 유지 → **호출부 변경 없음**

#### `src/services/authService.ts`
- `getPresignedUrl`, `uploadToS3` 메서드 완전 제거
- 인증·회원 로직(login, signup, getProfile 등)만 담도록 관심사 분리

#### `src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts`
- `authService.getPresignedUrl` + `authService.uploadToS3` 2단계 호출 → `imageService.uploadProfileImage` 단일 호출로 교체 (16줄 → 1줄)

#### `src/hooks/mutations/useMemberMutations.ts`
- 동일하게 프로필 수정 시 이미지 업로드 2단계 → `imageService.uploadProfileImage` 단일 호출로 교체 (10줄 → 1줄)

---

## 📸 스크린샷 (Screenshots)

UI 변경 없음 (내부 서비스 로직 리팩토링)

---

## ✅ 체크리스트 (Checklist)

- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
  - `npx tsc --noEmit` → 에러 0개 확인
- [ ] 린트 에러가 없나요? (`pnpm lint`)
  - 변경된 6개 파일 자체에서 발생한 신규 린트 에러 없음
  - 프로젝트 전체 기존 린트 에러(121개) 는 이번 PR 범위 외
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

---

## ⚠️ 비대상 파일 (범위 외 의도적 제외)

`src/lib/api/admin/image.ts` — admin 영역 전체가 `fetch` 직접 호출 패턴을 일관되게 사용 중이므로 이번 리팩토링 범위에서 제외했습니다.