### PR TITLE
fix(admin): 회원 신고 목록 API 응답 및 대상 링크 연동

### DIFF
--- a/src/components/base-ui/Admin/users/AdminUserTab.tsx
+++ b/src/components/base-ui/Admin/users/AdminUserTab.tsx
@@ -8,6 +8,7 @@ const USER_TABS: Array<{ id: AdminUserTabId; label: string }> = [
   { id: "meetings", label: "가입 모임" },
   { id: "stories", label: "책 이야기" },
   { id: "posts", label: "등록 소식" },
+  // 선택한 회원이 작성한 신고 이력
   { id: "reports", label: "신고 목록" },
 ];
 

--- a/src/components/base-ui/Admin/users/ReportList.tsx
+++ b/src/components/base-ui/Admin/users/ReportList.tsx
@@ -99,6 +99,7 @@ export default function ReportList({ memberNickname }: Props) {
       !inView ||
       !hasNext ||
       nextCursor === null ||
+      isNextPageError ||
       fetchingNextPageRef.current
     ) {
       return;
@@ -146,6 +147,7 @@ export default function ReportList({ memberNickname }: Props) {
     hasNext,
     nextCursor,
     memberNickname,
+    isNextPageError,
   ]);
 
   if (loading) {

--- a/src/components/base-ui/Admin/users/ReportList.tsx
+++ b/src/components/base-ui/Admin/users/ReportList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useInView } from "react-intersection-observer";
 import ReportItem from "./items/AdminReportItem";
 import {
   fetchAdminMemberReports,
@@ -12,32 +13,141 @@ type Props = {
   memberNickname: string;
 };
 
+const mergeReports = (
+  current: AdminMemberReportItem[],
+  incoming: AdminMemberReportItem[]
+) => {
+  const reportsById = new Map(
+    current.map((report) => [report.reportId, report])
+  );
+
+  incoming.forEach((report) => reportsById.set(report.reportId, report));
+  return Array.from(reportsById.values());
+};
+
+const formatReportedAt = (reportedAt: string) => {
+  const date = new Date(reportedAt);
+
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+};
+
 export default function ReportList({ memberNickname }: Props) {
   const [reports, setReports] = useState<AdminMemberReportItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(false);
   const [loading, setLoading] = useState(true);
   const [isError, setIsError] = useState(false);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+  const [isNextPageError, setIsNextPageError] = useState(false);
+  const [initialRetryCount, setInitialRetryCount] = useState(0);
+  const fetchingNextPageRef = useRef(false);
+
+  const { ref, inView } = useInView({ rootMargin: "200px" });
 
   useEffect(() => {
+    let active = true;
+
     const loadReports = async () => {
       try {
         setLoading(true);
         setIsError(false);
+        setIsNextPageError(false);
+        setReports([]);
+        setHasNext(false);
+        setNextCursor(null);
+        fetchingNextPageRef.current = false;
 
-        const res = await fetchAdminMemberReports(memberNickname);
+        const res = await fetchAdminMemberReports(memberNickname, null);
+
+        if (!active) return;
+
         setReports(res.result.reports ?? []);
+        setHasNext(res.result.hasNext ?? false);
+        setNextCursor(res.result.nextCursor ?? null);
       } catch (error) {
+        if (!active) return;
+
         console.error("신고 목록 조회 실패:", error);
         setReports([]);
+        setHasNext(false);
+        setNextCursor(null);
         setIsError(true);
       } finally {
-        setLoading(false);
+        if (active) {
+          setLoading(false);
+        }
       }
     };
 
     loadReports();
-  }, [memberNickname]);
 
-  // ✅ 로딩 상태
+    return () => {
+      active = false;
+    };
+  }, [memberNickname, initialRetryCount]);
+
+  useEffect(() => {
+    if (
+      !inView ||
+      !hasNext ||
+      nextCursor === null ||
+      fetchingNextPageRef.current
+    ) {
+      return;
+    }
+
+    let active = true;
+
+    const loadMoreReports = async () => {
+      fetchingNextPageRef.current = true;
+
+      try {
+        setIsFetchingNextPage(true);
+        setIsNextPageError(false);
+
+        const res = await fetchAdminMemberReports(memberNickname, nextCursor);
+
+        if (!active) return;
+
+        setReports((current) =>
+          mergeReports(current, res.result.reports ?? [])
+        );
+        setHasNext(res.result.hasNext ?? false);
+        setNextCursor(res.result.nextCursor ?? null);
+      } catch (error) {
+        if (!active) return;
+
+        console.error("신고 목록 추가 조회 실패:", error);
+        setIsNextPageError(true);
+      } finally {
+        fetchingNextPageRef.current = false;
+
+        if (active) {
+          setIsFetchingNextPage(false);
+        }
+      }
+    };
+
+    loadMoreReports();
+
+    return () => {
+      active = false;
+    };
+  }, [
+    inView,
+    hasNext,
+    nextCursor,
+    memberNickname,
+  ]);
+
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center py-10 w-full text-Gray-4 text-sm font-medium">
@@ -46,11 +156,17 @@ export default function ReportList({ memberNickname }: Props) {
     );
   }
 
-  // ✅ 에러 상태
-  if (!loading && isError) {
+  if (isError) {
     return (
-      <div className="flex flex-col items-center justify-center py-10 w-full text-red-500 text-sm font-medium">
-        멤버 신고 목록 불러오기 실패
+      <div className="flex flex-col items-center justify-center gap-[12px] py-10 w-full text-sm font-medium">
+        <p className="text-red-500">신고 목록을 불러오지 못했습니다.</p>
+        <button
+          type="button"
+          onClick={() => setInitialRetryCount((count) => count + 1)}
+          className="rounded-[6px] border border-Subbrown-4 px-[16px] py-[8px] text-Gray-6 hover:bg-Subbrown-5"
+        >
+          다시 시도
+        </button>
       </div>
     );
   }
@@ -59,23 +175,48 @@ export default function ReportList({ memberNickname }: Props) {
     return (
       <div className="w-full max-w-[1040px] mx-auto flex justify-center items-center py-[80px]">
         <div className="text-Gray-4 text-sm font-medium text-center">
-          멤버 신고 목록 없음
+          작성한 신고가 없습니다.
         </div>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-[16px] w-full max-w-[1040px] mx-auto">
-      {reports.map((report) => (
-        <ReportItem
-          key={report.reportId}
-          category={report.reportType}
-          reporterName={report.reportedMemberNickname}
-          content={report.content}
-          date={new Date(report.createdAt).toLocaleDateString()}
-        />
-      ))}
+    <div className="flex flex-col items-center gap-[16px] w-full max-w-[1040px] mx-auto">
+      <div className="flex flex-col gap-[16px] w-full">
+        {reports.map((report) => (
+          <ReportItem
+            key={report.reportId}
+            reason={report.reasonDescription}
+            content={report.content?.trim() || "입력된 신고 내용 없음"}
+            targetLabel={report.targetLabel}
+            targetUrl={report.targetUrl}
+            targetAvailable={report.targetAvailable}
+            reportedAt={formatReportedAt(report.reportedAt)}
+          />
+        ))}
+      </div>
+
+      {hasNext && !isNextPageError && <div ref={ref} className="h-4 w-full" />}
+
+      {isFetchingNextPage && (
+        <p className="py-4 text-center text-Gray-4">
+          추가 신고를 불러오는 중...
+        </p>
+      )}
+
+      {isNextPageError && (
+        <div className="flex flex-col items-center gap-[8px] py-4 text-sm">
+          <p className="text-red-500">추가 신고를 불러오지 못했습니다.</p>
+          <button
+            type="button"
+            onClick={() => setIsNextPageError(false)}
+            className="rounded-[6px] border border-Subbrown-4 px-[16px] py-[8px] text-Gray-6 hover:bg-Subbrown-5"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/base-ui/Admin/users/items/AdminReportItem.tsx
+++ b/src/components/base-ui/Admin/users/items/AdminReportItem.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 type Props = {
   reason: string;
   content: string;
@@ -17,11 +19,15 @@ export default function ReportItem({
   targetAvailable,
   reportedAt,
 }: Props) {
-  const canOpenTarget =
+  // 안전한 내부 URL("/..."으로 시작, "//" 외부 링크 제외)만 열 수 있도록 보장.
+  // 통과한 값은 string으로 좁혀져 next/link의 href 타입과 호환된다.
+  const safeTargetUrl =
     targetAvailable &&
     targetUrl !== null &&
     targetUrl.startsWith("/") &&
-    !targetUrl.startsWith("//");
+    !targetUrl.startsWith("//")
+      ? targetUrl
+      : null;
 
   return (
     <div
@@ -53,16 +59,16 @@ export default function ReportItem({
 
         <div className="min-w-0 border-t border-Subbrown-4 pt-[12px]">
           <p className="body_2_2 text-Gray-6">신고 대상</p>
-          {canOpenTarget ? (
-            <a
-              href={targetUrl}
+          {safeTargetUrl ? (
+            <Link
+              href={safeTargetUrl}
               target="_blank"
               rel="noopener noreferrer"
               aria-label="신고 대상 새 탭에서 열기"
               className="mt-[4px] inline-block break-all body_2_3 text-primary-1 underline underline-offset-2 hover:text-primary-3 focus-visible:rounded-[2px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-1"
             >
               {targetLabel}
-            </a>
+            </Link>
           ) : (
             <div className="mt-[4px]">
               <p className="break-words body_2_3 text-Gray-4">

--- a/src/components/base-ui/Admin/users/items/AdminReportItem.tsx
+++ b/src/components/base-ui/Admin/users/items/AdminReportItem.tsx
@@ -1,74 +1,79 @@
 "use client";
 
-import Image from "next/image";
-import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
-
 type Props = {
-  category: string;
-  reporterName: string;
+  reason: string;
   content: string;
-  date: string;
+  targetLabel: string;
+  targetUrl: string | null;
+  targetAvailable: boolean;
+  reportedAt: string;
 };
 
 export default function ReportItem({
-  category,
-  reporterName,
+  reason,
   content,
-  date,
+  targetLabel,
+  targetUrl,
+  targetAvailable,
+  reportedAt,
 }: Props) {
+  const canOpenTarget =
+    targetAvailable &&
+    targetUrl !== null &&
+    targetUrl.startsWith("/") &&
+    !targetUrl.startsWith("//");
+
   return (
     <div
-      className="flex items-start rounded-[8px] border border-Subbrown-4 bg-White p-[20px]
-      w-full gap-[40px]
-      md:w-[440px]
-      xl:w-[1000px]"
+      className="flex w-full flex-col gap-[16px] rounded-[8px] border border-Subbrown-4 bg-White p-[20px]
+      md:flex-row md:items-start md:gap-[24px] xl:px-[28px]"
     >
-      {/* 카테고리 뱃지 */}
-      <div className="flex w-[60px] shrink-0 items-center justify-center gap-[10px] rounded-[4px] bg-Red p-[4px]">
+      <div className="flex min-w-[72px] shrink-0 items-center justify-center rounded-[4px] bg-Red px-[8px] py-[4px]">
         <span
           className="text-White
           text-[12px] font-medium leading-[145%] tracking-[-0.012px]
           md:body_2_2"
         >
-          {category}
+          {reason}
         </span>
       </div>
 
-      {/* 컨텐츠 영역 */}
-      <div
-        className="flex flex-col items-start
-        w-[199px] gap-[6px]
-        md:w-[280px] md:gap-[12px]
-        xl:w-auto xl:flex-1"
-      >
-        <div className="flex items-start justify-between w-full">
-          <div className="flex items-center gap-[8px]">
-            <div className="relative h-[24px] w-[24px] shrink-0">
-              <Image
-                src={DEFAULT_PROFILE_IMAGE}
-                alt="profile"
-                fill
-                className="object-cover rounded-full"
-              />
-            </div>
-            <span className="body_1_2 text-Gray-7">{reporterName}</span>
+      <div className="flex min-w-0 flex-1 flex-col gap-[14px]">
+        <div className="flex flex-col-reverse gap-[8px] md:flex-row md:items-start md:justify-between">
+          <div className="min-w-0">
+            <p className="body_2_2 text-Gray-6">신고 내용</p>
+            <p className="mt-[4px] whitespace-pre-wrap break-words body_2_3 text-Gray-5">
+              {content}
+            </p>
           </div>
-          <span
-            className="text-Gray-3
-            text-[12px] font-normal leading-[145%] tracking-[-0.012px]
-            md:body_2_3"
-          >
-            {date}
+          <span className="shrink-0 text-[12px] font-normal leading-[145%] tracking-[-0.012px] text-Gray-3 md:body_2_3">
+            {reportedAt}
           </span>
         </div>
 
-        <p
-          className="text-Gray-5 self-stretch whitespace-pre-wrap
-          text-[12px] font-normal leading-[145%] tracking-[-0.012px]
-          md:body_2_3"
-        >
-          {content}
-        </p>
+        <div className="min-w-0 border-t border-Subbrown-4 pt-[12px]">
+          <p className="body_2_2 text-Gray-6">신고 대상</p>
+          {canOpenTarget ? (
+            <a
+              href={targetUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="신고 대상 새 탭에서 열기"
+              className="mt-[4px] inline-block break-all body_2_3 text-primary-1 underline underline-offset-2 hover:text-primary-3 focus-visible:rounded-[2px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-1"
+            >
+              {targetLabel}
+            </a>
+          ) : (
+            <div className="mt-[4px]">
+              <p className="break-words body_2_3 text-Gray-4">
+                {targetLabel || "삭제되었거나 확인할 수 없는 대상"}
+              </p>
+              <p className="mt-[2px] text-[12px] text-Gray-3">
+                대상 페이지 없음
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/lib/api/admin/member.ts
+++ b/src/lib/api/admin/member.ts
@@ -133,35 +133,50 @@ export async function fetchAdminMemberDetail(
 
 export type AdminMemberReportItem = {
   reportId: number;
-  reportedMemberNickname: string;
-  reportedMemberProfileImageUrl: string;
-  reportType: string;
-  content: string;
-  createdAt: string;
+  reason: string;
+  reasonDescription: string;
+  content: string | null;
+  targetType: string;
+  targetTypeDescription: string;
+  targetId: string;
+  targetLabel: string;
+  targetAvailable: boolean;
+  targetUrl: string | null;
+  reportedAt: string;
 };
 
 export type AdminMemberReportsResult = {
   reports: AdminMemberReportItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
 };
 
 export type AdminMemberReportsResponse = ApiResponse<AdminMemberReportsResult>;
 
 export async function fetchAdminMemberReports(
-  memberNickName: string
+  memberNickName: string,
+  cursorId?: number | null
 ): Promise<AdminMemberReportsResponse> {
   const encodedNickname = encodeURIComponent(memberNickName);
+  const params = new URLSearchParams();
 
-  const res = await fetch(
-    ADMIN_MEMBER_ENDPOINTS.GET_MEMBER_REPORTS(encodedNickname),
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        Accept: "application/json",
-      },
-      cache: "no-store",
-    }
-  );
+  if (cursorId !== undefined && cursorId !== null) {
+    params.append("cursorId", String(cursorId));
+  }
+
+  const query = params.toString();
+  const url = query
+    ? `${ADMIN_MEMBER_ENDPOINTS.GET_MEMBER_REPORTS(encodedNickname)}?${query}`
+    : ADMIN_MEMBER_ENDPOINTS.GET_MEMBER_REPORTS(encodedNickname);
+
+  const res = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
 
   if (!res.ok) {
     throw new Error(`회원 신고 목록 조회 실패 (${res.status})`);


### PR DESCRIPTION
## 📌 개요 (Summary)
- 관리자 회원 상세의 신고 목록을 신규 백엔드 응답 형식에 맞게 수정했습니다.
- 신고 내용과 신고 대상을 구분해 표시하고, 유효한 대상은 새 탭에서 열 수 있도록 연동했습니다.
- Closes #399

## 🛠 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타

- 신고 사유, 내용, 대상, 신고 일자를 표시하도록 응답 타입을 변경했습니다.
- 삭제된 대상은 링크 없이 `대상 페이지 없음`으로 표시합니다.
- 커서 기반 무한 스크롤과 다음 페이지 재시도를 적용했습니다.
- 중복 신고 항목이 추가되지 않도록 `reportId` 기준으로 병합합니다.
- 신고 내용이 없을 경우 대체 문구를 표시합니다.

## 📸 스크린샷 (Screenshots)
- 관리자 > 회원 관리 > 회원 상세 > 신고 목록
<!-- 정상 대상 및 삭제된 대상 화면을 첨부해주세요. -->

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 전체 린트 에러가 없나요? (`pnpm lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

## 🔍 검증 결과
- [x] 변경 파일 ESLint 통과
- [x] `npx tsc --noEmit` 통과
- 전체 lint는 기존 프로젝트 오류로 실패합니다.
- production build는 Google Fonts 네트워크 접근 제한으로 완료하지 못했습니다.