### PR TITLE
feat: 모임 상세 회원 목록 조회 UI 추가

### DIFF
--- a/src/app/(main)/groups/[id]/GroupDetailClient.tsx
+++ b/src/app/(main)/groups/[id]/GroupDetailClient.tsx
@@ -3,7 +3,8 @@
 import Image from "next/image";
 import { useRouter, useParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useInView } from "react-intersection-observer";
 import toast from "react-hot-toast";
 
 import ClubCategoryTags from "@/components/base-ui/Group-Search/search_clublist/search_club_category_tags";
@@ -13,25 +14,11 @@ import GroupAdminMenu from "@/components/base-ui/Group/group_admin_menu";
 import { clubhomeKeys, useClubhomeQueries, useClubParticipantsInfiniteQuery } from "@/hooks/queries/useClubhomeQueries";
 import { useToggleFollowMutation } from "@/hooks/mutations/useMemberMutations";
 import { isClubMember } from "@/hooks/useClubAccessGuard";
-import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
 import { useAuthStore } from "@/store/useAuthStore";
-import type { ClubParticipant } from "@/types/groups/grouphome";
+import FollowItem from "@/components/base-ui/Profile/Follow/FollowItem";
 
 const DEFAULT_CLUB_IMG = "/default_profile_1.svg";
 const PRIVATE_PARTICIPANTS_MESSAGE = "모임 회원은 가입 후에 조회 가능합니다";
-
-function safeProfileImageSrc(src: string | null | undefined) {
-  if (!src) return DEFAULT_PROFILE_IMAGE;
-
-  const value = src.trim();
-  if (!value || value === "string") return DEFAULT_PROFILE_IMAGE;
-
-  if (value.startsWith("http://") || value.startsWith("https://") || value.startsWith("/")) {
-    return value;
-  }
-
-  return DEFAULT_PROFILE_IMAGE;
-}
 
 export default function GroupDetailClient() {
   const router = useRouter();
@@ -43,6 +30,15 @@ export default function GroupDetailClient() {
 
   const { meQuery, homeQuery, latestNoticeQuery, nextMeetingQuery } = useClubhomeQueries(groupId);
   const participantsQuery = useClubParticipantsInfiniteQuery(groupId, Number.isFinite(groupId) && groupId > 0);
+
+  // 회원 목록 무한 스크롤 (하단 sentinel이 보이면 다음 페이지 자동 로드)
+  const { ref: loadMoreRef, inView: loadMoreInView } = useInView({ rootMargin: "200px" });
+  useEffect(() => {
+    if (loadMoreInView && participantsQuery.hasNextPage && !participantsQuery.isFetchingNextPage) {
+      participantsQuery.fetchNextPage();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadMoreInView, participantsQuery.hasNextPage, participantsQuery.isFetchingNextPage, participantsQuery.fetchNextPage]);
 
   const isLoading =
     meQuery.isLoading || homeQuery.isLoading || latestNoticeQuery.isLoading || nextMeetingQuery.isLoading;
@@ -132,15 +128,11 @@ export default function GroupDetailClient() {
     router.push(joinUrl);
   };
 
-  const goProfile = (nickname: string) => {
-    router.push(`/profile/${encodeURIComponent(nickname)}`);
-  };
-
-  const onToggleFollow = (participant: ClubParticipant) => {
+  const handleToggleFollow = (id: string | number, isFollowing: boolean) => {
     toggleFollowMutation.mutate(
       {
-        nickname: participant.nickname,
-        isFollowing: participant.following,
+        nickname: String(id),
+        isFollowing,
       },
       {
         onSettled: () => {
@@ -323,90 +315,46 @@ export default function GroupDetailClient() {
           )}
 
           {!participantsQuery.isLoading && !participantsQuery.isError && participants.length > 0 && (
-            <div className="grid grid-cols-1 gap-3 t:grid-cols-2 d:gap-4">
+            <div className="flex w-full flex-col items-start gap-2">
               {participants.map((participant) => {
                 const isMe = currentNickname === participant.nickname;
-                const followLabel = participant.following ? "구독중" : "구독";
-                const isTogglePending = toggleFollowMutation.isPending;
+                const roleLabel =
+                  participant.clubMemberStatus === "OWNER"
+                    ? "개설자"
+                    : participant.clubMemberStatus === "STAFF"
+                      ? "운영진"
+                      : "회원";
 
                 return (
-                  <article
+                  <FollowItem
                     key={participant.clubMemberId}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => goProfile(participant.nickname)}
-                    onKeyDown={(event) => {
-                      if (event.key !== "Enter" && event.key !== " ") return;
-                      event.preventDefault();
-                      goProfile(participant.nickname);
+                    user={{
+                      id: participant.nickname,
+                      nickname: participant.nickname,
+                      profileImageUrl: participant.profileImageUrl ?? undefined,
+                      isFollowing: participant.following,
                     }}
-                    className="group flex min-h-[76px] w-full items-center gap-3 rounded-[8px] border border-Subbrown-3 bg-White px-4 py-3 text-left transition hover:-translate-y-[1px] hover:brightness-98 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-Subbrown-2"
-                    aria-label={`${participant.nickname} 프로필 보기`}
-                  >
-                    <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-full bg-Gray-1">
-                      <Image
-                        src={safeProfileImageSrc(participant.profileImageUrl)}
-                        alt={`${participant.nickname} 프로필 이미지`}
-                        fill
-                        className="object-cover"
-                        sizes="44px"
-                      />
-                    </div>
-
-                    <div className="min-w-0 flex-1">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <p className="body_1_2 min-w-0 truncate text-Gray-7 group-hover:underline">
-                          {participant.nickname}
-                        </p>
-                        {participant.staff && (
-                          <span className="inline-flex h-6 shrink-0 items-center gap-1 rounded-full bg-Subbrown-4 px-2 text-[12px] font-medium leading-none text-primary-3">
-                            <Image src="/admin.svg" alt="" width={14} height={14} className="object-contain" />
-                            운영진
-                          </span>
-                        )}
-                      </div>
-                      <p className="mt-1 body_2_3 text-Gray-4">
-                        {participant.clubMemberStatus === "OWNER"
-                          ? "개설자"
-                          : participant.clubMemberStatus === "STAFF"
-                            ? "운영진"
-                            : "회원"}
-                      </p>
-                    </div>
-
-                    {!isMe && (
-                      <button
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onToggleFollow(participant);
-                        }}
-                        disabled={isTogglePending}
-                        className={`h-9 w-[72px] shrink-0 rounded-[4px] border px-3 body_2_1 transition disabled:cursor-not-allowed disabled:opacity-50 ${
-                          participant.following
-                            ? "border-Subbrown-3 bg-White text-Gray-5 hover:bg-Subbrown-4"
-                            : "border-primary-1 bg-primary-1 text-White hover:brightness-90"
-                        }`}
-                      >
-                        {followLabel}
-                      </button>
-                    )}
-                  </article>
+                    onToggleFollow={handleToggleFollow}
+                    hideFollow={isMe}
+                    subLabel={roleLabel}
+                    badge={
+                      participant.staff ? (
+                        <span className="inline-flex h-6 shrink-0 items-center gap-1 rounded-full bg-Subbrown-4 px-2 text-[12px] font-medium leading-none text-primary-3">
+                          <Image src="/admin.svg" alt="" width={14} height={14} className="object-contain" />
+                          운영진
+                        </span>
+                      ) : undefined
+                    }
+                  />
                 );
               })}
-            </div>
-          )}
 
-          {participantsQuery.hasNextPage && !participantsQuery.isError && (
-            <div className="mt-4 flex justify-center">
-              <button
-                type="button"
-                onClick={() => participantsQuery.fetchNextPage()}
-                disabled={participantsQuery.isFetchingNextPage}
-                className="h-10 min-w-[120px] rounded-[4px] border border-Subbrown-2 bg-Subbrown-4 px-4 body_1_2 text-primary-3 transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {participantsQuery.isFetchingNextPage ? "불러오는 중..." : "더보기"}
-              </button>
+              {participantsQuery.hasNextPage && (
+                <div ref={loadMoreRef} className="h-5 w-full shrink-0" />
+              )}
+              {participantsQuery.isFetchingNextPage && (
+                <div className="w-full py-3 text-center body_2_3 text-Gray-4">불러오는 중...</div>
+              )}
             </div>
           )}
         </section>

--- a/src/app/(main)/groups/[id]/GroupDetailClient.tsx
+++ b/src/app/(main)/groups/[id]/GroupDetailClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useRouter, useParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
@@ -9,17 +10,39 @@ import ClubCategoryTags from "@/components/base-ui/Group-Search/search_clublist/
 import ButtonWithoutImg from "@/components/base-ui/button_without_img";
 import GroupAdminMenu from "@/components/base-ui/Group/group_admin_menu";
 
-import { useClubhomeQueries } from "@/hooks/queries/useClubhomeQueries";
+import { clubhomeKeys, useClubhomeQueries, useClubParticipantsInfiniteQuery } from "@/hooks/queries/useClubhomeQueries";
+import { useToggleFollowMutation } from "@/hooks/mutations/useMemberMutations";
 import { isClubMember } from "@/hooks/useClubAccessGuard";
+import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { useAuthStore } from "@/store/useAuthStore";
+import type { ClubParticipant } from "@/types/groups/grouphome";
 
 const DEFAULT_CLUB_IMG = "/default_profile_1.svg";
+const PRIVATE_PARTICIPANTS_MESSAGE = "모임 회원은 가입 후에 조회 가능합니다";
+
+function safeProfileImageSrc(src: string | null | undefined) {
+  if (!src) return DEFAULT_PROFILE_IMAGE;
+
+  const value = src.trim();
+  if (!value || value === "string") return DEFAULT_PROFILE_IMAGE;
+
+  if (value.startsWith("http://") || value.startsWith("https://") || value.startsWith("/")) {
+    return value;
+  }
+
+  return DEFAULT_PROFILE_IMAGE;
+}
 
 export default function GroupDetailClient() {
   const router = useRouter();
   const params = useParams();
   const groupId = Number(params.id);
+  const queryClient = useQueryClient();
+  const currentNickname = useAuthStore((state) => state.user?.nickname);
+  const toggleFollowMutation = useToggleFollowMutation();
 
   const { meQuery, homeQuery, latestNoticeQuery, nextMeetingQuery } = useClubhomeQueries(groupId);
+  const participantsQuery = useClubParticipantsInfiniteQuery(groupId, Number.isFinite(groupId) && groupId > 0);
 
   const isLoading =
     meQuery.isLoading || homeQuery.isLoading || latestNoticeQuery.isLoading || nextMeetingQuery.isLoading;
@@ -27,6 +50,19 @@ export default function GroupDetailClient() {
   const isError = meQuery.isError || homeQuery.isError;
 
   const [isContactOpen, setIsContactOpen] = useState(false);
+
+  const modalLinks = useMemo(() => {
+    const list = homeQuery.data?.links ?? [];
+    return list
+      .map((x, idx) => {
+        const raw = (x.link ?? "").trim();
+        if (!raw) return null;
+        const url = /^(https?:\/\/)/i.test(raw) ? raw : `http://${raw}`;
+        const label = (x.label ?? "").trim() || `링크 ${idx + 1}`;
+        return { id: `${idx}`, url, label };
+      })
+      .filter(Boolean) as { id: string; url: string; label: string }[];
+  }, [homeQuery.data?.links]);
 
   if (!Number.isFinite(groupId) || groupId <= 0) {
     return (
@@ -64,6 +100,11 @@ export default function GroupDetailClient() {
 
   const isAdmin = me.staff === true;
   const canAccessMemberOnlyPage = isClubMember(me);
+  const participants = participantsQuery.data?.pages.flatMap((page) => page.clubMembers) ?? [];
+  const totalParticipants = participantsQuery.data?.pages[0]?.totalCount ?? null;
+  const participantsErrorMessage = participantsQuery.error?.message ?? "";
+  const isParticipantsPrivateBlocked =
+    participantsQuery.isError && participantsErrorMessage.includes(PRIVATE_PARTICIPANTS_MESSAGE);
 
   const noticeText = latestNotice?.title ?? "아직 등록된 공지사항이 없습니다.";
   const hasNotice = Boolean(latestNotice?.id);
@@ -79,19 +120,6 @@ export default function GroupDetailClient() {
   const joinMeetingId = nextMeeting?.meetingId ?? null;
   const joinUrl = joinMeetingId ? `/groups/${groupId}/bookcase/${joinMeetingId}` : null;
 
-  const modalLinks = useMemo(() => {
-    const list = home.links ?? [];
-    return list
-      .map((x, idx) => {
-        const raw = (x.link ?? "").trim();
-        if (!raw) return null;
-        const url = /^(https?:\/\/)/i.test(raw) ? raw : `http://${raw}`;
-        const label = (x.label ?? "").trim() || `링크 ${idx + 1}`;
-        return { id: `${idx}`, url, label };
-      })
-      .filter(Boolean) as { id: string; url: string; label: string }[];
-  }, [home.links]);
-
   const onClickJoin = () => {
     if (!canAccessMemberOnlyPage) {
       toast.error("회원만 접근이 가능합니다.");
@@ -102,6 +130,24 @@ export default function GroupDetailClient() {
       return;
     }
     router.push(joinUrl);
+  };
+
+  const goProfile = (nickname: string) => {
+    router.push(`/profile/${encodeURIComponent(nickname)}`);
+  };
+
+  const onToggleFollow = (participant: ClubParticipant) => {
+    toggleFollowMutation.mutate(
+      {
+        nickname: participant.nickname,
+        isFollowing: participant.following,
+      },
+      {
+        onSettled: () => {
+          queryClient.invalidateQueries({ queryKey: clubhomeKeys.participants(groupId) });
+        },
+      }
+    );
   };
 
   return (
@@ -241,6 +287,129 @@ export default function GroupDetailClient() {
             </div>
           </div>
         </div>
+
+        <section className="mt-10 w-full">
+          <div className="mb-4 flex flex-col gap-1 t:flex-row t:items-end t:justify-between">
+            <div>
+              <h2 className="subhead_3_1 text-Gray-7">모임 회원</h2>
+              <p className="body_1_3 text-Gray-4">
+                {totalParticipants == null ? "참여 인원을 확인하고 있습니다." : `총 ${totalParticipants}명`}
+              </p>
+            </div>
+          </div>
+
+          {participantsQuery.isLoading && (
+            <div className="rounded-[8px] border border-Subbrown-3 bg-White px-4 py-6 body_1_2 text-Gray-5">
+              모임 회원 불러오는 중...
+            </div>
+          )}
+
+          {!participantsQuery.isLoading && isParticipantsPrivateBlocked && (
+            <div className="rounded-[8px] border border-Subbrown-3 bg-White px-4 py-6 body_1_2 text-Gray-5">
+              {PRIVATE_PARTICIPANTS_MESSAGE}
+            </div>
+          )}
+
+          {!participantsQuery.isLoading && participantsQuery.isError && !isParticipantsPrivateBlocked && (
+            <div className="rounded-[8px] border border-Subbrown-3 bg-White px-4 py-6 body_1_2 text-Red">
+              모임 회원을 불러오지 못했습니다.
+            </div>
+          )}
+
+          {!participantsQuery.isLoading && !participantsQuery.isError && participants.length === 0 && (
+            <div className="rounded-[8px] border border-Subbrown-3 bg-White px-4 py-6 body_1_2 text-Gray-5">
+              아직 참여 중인 회원이 없습니다.
+            </div>
+          )}
+
+          {!participantsQuery.isLoading && !participantsQuery.isError && participants.length > 0 && (
+            <div className="grid grid-cols-1 gap-3 t:grid-cols-2 d:gap-4">
+              {participants.map((participant) => {
+                const isMe = currentNickname === participant.nickname;
+                const followLabel = participant.following ? "구독중" : "구독";
+                const isTogglePending = toggleFollowMutation.isPending;
+
+                return (
+                  <article
+                    key={participant.clubMemberId}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => goProfile(participant.nickname)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" && event.key !== " ") return;
+                      event.preventDefault();
+                      goProfile(participant.nickname);
+                    }}
+                    className="group flex min-h-[76px] w-full items-center gap-3 rounded-[8px] border border-Subbrown-3 bg-White px-4 py-3 text-left transition hover:-translate-y-[1px] hover:brightness-98 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-Subbrown-2"
+                    aria-label={`${participant.nickname} 프로필 보기`}
+                  >
+                    <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-full bg-Gray-1">
+                      <Image
+                        src={safeProfileImageSrc(participant.profileImageUrl)}
+                        alt={`${participant.nickname} 프로필 이미지`}
+                        fill
+                        className="object-cover"
+                        sizes="44px"
+                      />
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <p className="body_1_2 min-w-0 truncate text-Gray-7 group-hover:underline">
+                          {participant.nickname}
+                        </p>
+                        {participant.staff && (
+                          <span className="inline-flex h-6 shrink-0 items-center gap-1 rounded-full bg-Subbrown-4 px-2 text-[12px] font-medium leading-none text-primary-3">
+                            <Image src="/admin.svg" alt="" width={14} height={14} className="object-contain" />
+                            운영진
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 body_2_3 text-Gray-4">
+                        {participant.clubMemberStatus === "OWNER"
+                          ? "개설자"
+                          : participant.clubMemberStatus === "STAFF"
+                            ? "운영진"
+                            : "회원"}
+                      </p>
+                    </div>
+
+                    {!isMe && (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onToggleFollow(participant);
+                        }}
+                        disabled={isTogglePending}
+                        className={`h-9 w-[72px] shrink-0 rounded-[4px] border px-3 body_2_1 transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                          participant.following
+                            ? "border-Subbrown-3 bg-White text-Gray-5 hover:bg-Subbrown-4"
+                            : "border-primary-1 bg-primary-1 text-White hover:brightness-90"
+                        }`}
+                      >
+                        {followLabel}
+                      </button>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+
+          {participantsQuery.hasNextPage && !participantsQuery.isError && (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={() => participantsQuery.fetchNextPage()}
+                disabled={participantsQuery.isFetchingNextPage}
+                className="h-10 min-w-[120px] rounded-[4px] border border-Subbrown-2 bg-Subbrown-4 px-4 body_1_2 text-primary-3 transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {participantsQuery.isFetchingNextPage ? "불러오는 중..." : "더보기"}
+              </button>
+            </div>
+          )}
+        </section>
       </div>
 
       {isContactOpen && (

--- a/src/components/base-ui/Profile/Follow/FollowItem.tsx
+++ b/src/components/base-ui/Profile/Follow/FollowItem.tsx
@@ -16,9 +16,15 @@ type FollowItemProps = {
     user: FollowUser;
     onToggleFollow: (id: string | number, isFollowing: boolean) => void;
     onDelete?: (nickname: string) => void;
+    /** 닉네임 옆 인라인 배지 (예: 운영진) */
+    badge?: React.ReactNode;
+    /** 닉네임 아래 보조 라벨 (예: 개설자 / 회원) */
+    subLabel?: string;
+    /** 구독 버튼 숨김 (예: 본인) */
+    hideFollow?: boolean;
 };
 
-export default function FollowItem({ user, onToggleFollow, onDelete }: FollowItemProps) {
+export default function FollowItem({ user, onToggleFollow, onDelete, badge, subLabel, hideFollow }: FollowItemProps) {
     const isDeleted = user.isDeleted ?? false;
 
     const isDeletingRef = useRef(false);
@@ -30,8 +36,8 @@ export default function FollowItem({ user, onToggleFollow, onDelete }: FollowIte
     };
 
     return (
-        <div className="flex w-full max-w-[1040px] p-[20px] justify-between items-center rounded-[8px] border border-Subbrown-4 bg-White">
-            <Link href={`/profile/${user.nickname}`} className="flex items-center gap-[12px] cursor-pointer">
+        <div className="flex w-full max-w-[1040px] p-[20px] justify-between items-center gap-[12px] rounded-[8px] border border-Subbrown-4 bg-White transition-colors hover:bg-Subbrown-5">
+            <Link href={`/profile/${user.nickname}`} className="group flex items-center gap-[12px] cursor-pointer min-w-0">
                 <div className="flex w-[40px] h-[40px] justify-center items-center shrink-0 rounded-full overflow-hidden relative">
                     <Image
                         src={isValidUrl(user.profileImageUrl) ? user.profileImageUrl : DEFAULT_PROFILE_IMAGE}
@@ -40,7 +46,15 @@ export default function FollowItem({ user, onToggleFollow, onDelete }: FollowIte
                         className="object-cover"
                     />
                 </div>
-                <span className="text-Gray-7 subhead_4_1">{user.nickname}</span>
+                <div className="min-w-0">
+                    <div className="flex items-center gap-[6px] min-w-0">
+                        <span className="text-Gray-7 subhead_4_1 truncate group-hover:underline">{user.nickname}</span>
+                        {badge}
+                    </div>
+                    {subLabel && (
+                        <span className="block mt-[2px] body_2_3 text-Gray-4">{subLabel}</span>
+                    )}
+                </div>
             </Link>
 
             {onDelete && (
@@ -48,9 +62,9 @@ export default function FollowItem({ user, onToggleFollow, onDelete }: FollowIte
                     type="button"
                     onClick={handleDelete}
                     disabled={isDeleted}
-                    className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] transition-colors ${isDeleted
+                    className={`flex shrink-0 px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] transition-colors ${isDeleted
                         ? "bg-Subbrown-4 text-primary-3 cursor-not-allowed opacity-50"
-                        : "bg-Red text-White cursor-pointer"
+                        : "bg-Red text-White cursor-pointer hover:brightness-95"
                         }`}
                 >
                     <span className="font-sans text-[12px] font-semibold leading-[100%] tracking-[-0.012px]">
@@ -58,13 +72,13 @@ export default function FollowItem({ user, onToggleFollow, onDelete }: FollowIte
                     </span>
                 </button>
             )}
-            {!onDelete && (
+            {!onDelete && !hideFollow && (
                 <button
                     type="button"
                     onClick={() => onToggleFollow(user.id, user.isFollowing)}
-                    className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] transition-colors cursor-pointer ${user.isFollowing
-                        ? "bg-Subbrown-4 text-primary-3"
-                        : "bg-primary-2 text-White"
+                    className={`flex shrink-0 px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] transition-colors cursor-pointer ${user.isFollowing
+                        ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+                        : "bg-primary-2 text-White hover:bg-primary-1"
                         }`}
                 >
                     <span className="font-sans text-[12px] font-semibold leading-[100%] tracking-[-0.012px]">

--- a/src/components/base-ui/home/Club/home_bookclub.tsx
+++ b/src/components/base-ui/home/Club/home_bookclub.tsx
@@ -88,7 +88,7 @@ export default function HomeBookclub({ groups }: Props) {
             <button
               type="button"
               onClick={() => setOpen((v) => !v)}
-              className="w-full h-[38px] rounded-[6px] bg-transparent text-[13px] flex items-center justify-center gap-[6px] text-Gray-3"
+              className="w-full h-[38px] rounded-[6px] bg-transparent text-[13px] flex items-center justify-center gap-[6px] text-Gray-3 cursor-pointer transition-colors hover:bg-white/50"
             >
               {open ? (
                 <div className="flex items-center justify-center gap-1">
@@ -107,8 +107,7 @@ export default function HomeBookclub({ groups }: Props) {
               <button
                 type="button"
                 onClick={handleSearchGroup}
-                className="w-full h-[32px] t:h-[48px] py-3 rounded-[8px] bg-white border border-[#E6E6E6]
-                          text-[13px] flex items-center justify-center gap-2"
+                className="w-full h-[32px] t:h-[48px] py-3 rounded-[8px] bg-white border border-[#E6E6E6] text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-98 hover:-translate-y-[1px]"
               >
                 <Image
                   src="/search.svg"
@@ -123,8 +122,7 @@ export default function HomeBookclub({ groups }: Props) {
               <button
                 type="button"
                 onClick={handleCreateGroup}
-                className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-[#6B5448] text-white
-                          text-[13px] flex items-center justify-center gap-2 cursor-pointer"
+                className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-[#6B5448] text-white text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-90 hover:-translate-y-[1px]"
               >
                 <Image
                   src="/icon_plus.svg"

--- a/src/hooks/queries/useClubhomeQueries.ts
+++ b/src/hooks/queries/useClubhomeQueries.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, type InfiniteData } from "@tanstack/react-query";
 import { clubService } from "@/services/clubService";
+import type { ClubParticipantsResponseResult } from "@/types/groups/grouphome";
 
 export const clubhomeKeys = {
   all: (clubId: number) => ["clubhome", clubId] as const,
@@ -7,6 +8,7 @@ export const clubhomeKeys = {
   home: (clubId: number) => [...clubhomeKeys.all(clubId), "home"] as const,
   latestNotice: (clubId: number) => [...clubhomeKeys.all(clubId), "latestNotice"] as const,
   nextMeeting: (clubId: number) => [...clubhomeKeys.all(clubId), "nextMeeting"] as const,
+  participants: (clubId: number) => [...clubhomeKeys.all(clubId), "participants"] as const,
 };
 
 export function useClubhomeQueries(clubId: number) {
@@ -53,5 +55,29 @@ export function useClubMeQuery(clubId: number) {
     queryKey: clubhomeKeys.me(clubId),
     queryFn: () => clubService.getMyStatus(clubId),
     enabled,
+  });
+}
+
+export function useClubParticipantsInfiniteQuery(clubId: number, enabled = true) {
+  const canFetch = enabled && Number.isFinite(clubId) && clubId > 0;
+
+  return useInfiniteQuery<
+    ClubParticipantsResponseResult,
+    Error,
+    InfiniteData<ClubParticipantsResponseResult, number | null>,
+    ReturnType<typeof clubhomeKeys.participants>,
+    number | null
+  >({
+    queryKey: clubhomeKeys.participants(clubId),
+    enabled: canFetch,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      clubService.getClubParticipants({
+        clubId,
+        cursorId: pageParam ?? null,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor ?? undefined : undefined,
+    retry: false,
   });
 }

--- a/src/lib/api/endpoints/Clubs.ts
+++ b/src/lib/api/endpoints/Clubs.ts
@@ -17,6 +17,7 @@ export const CLUBS = {
 
   members: (clubId: number) => `${API_BASE_URL}/clubs/${clubId}/members`, // GET
   member: (clubId: number, clubMemberId: number) => `${API_BASE_URL}/clubs/${clubId}/members/${clubMemberId}`, // PATCH
+  participants: (clubId: number) => `${API_BASE_URL}/clubs/${clubId}/participants`,
 
   detail: (clubId: number) => `${API_BASE_URL}/clubs/${clubId}`,
   update: (clubId: number) => `${API_BASE_URL}/clubs/${clubId}`,

--- a/src/services/clubService.ts
+++ b/src/services/clubService.ts
@@ -5,8 +5,11 @@ import type { ApiResponse } from "@/lib/api/types";
 import { ClubAdminDetailResponse, UpdateClubAdminRequest, UpdateClubAdminResponse } from "@/types/groups/clubAdminEdit";
 import { CreateClubRequest } from "@/types/groups/clubCreate";
 import { ClubJoinRequest, ClubJoinResponse, ClubSearchParams, ClubSearchResponse, MyClubsResponse, RecommendationsResponse } from "@/types/groups/clubsearch";
-import { ClubHomeResponse, ClubHomeResponseResult, LatestNoticeResponse, MyClubStatusResponse, MyClubStatusResponseResult, NextMeetingResponse } from "@/types/groups/grouphome";
+import { ClubHomeResponse, ClubHomeResponseResult, ClubParticipantsResponse, ClubParticipantsResponseResult, LatestNoticeResponse, MyClubStatusResponse, MyClubStatusResponseResult, NextMeetingResponse } from "@/types/groups/grouphome";
 
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "";
+}
 
 export const clubService = {
   // GET /api/clubs/check-name?clubName=...
@@ -77,8 +80,8 @@ export const clubService = {
     try {
       const res = await apiClient.get<LatestNoticeResponse>(CLUBS.latestNotice(clubId));
       return res.result;
-    } catch (e: any) {
-      const msg = e?.message ?? "";
+    } catch (e: unknown) {
+      const msg = getErrorMessage(e);
       if (
         msg.includes("공지") && (msg.includes("없") || msg.includes("존재하지"))
       ) {
@@ -92,8 +95,8 @@ export const clubService = {
     try {
       const res = await apiClient.get<NextMeetingResponse>(CLUBS.nextMeeting(clubId));
       return res.result;
-    } catch (e: any) {
-      const msg = e?.message ?? "";
+    } catch (e: unknown) {
+      const msg = getErrorMessage(e);
       if (msg.includes("다음 정기모임이 존재하지 않습니다")) {
         return null;
       }
@@ -102,6 +105,18 @@ export const clubService = {
       }
       throw e;
     }
+  },
+  getClubParticipants: async (params: {
+    clubId: number;
+    cursorId?: number | null;
+  }): Promise<ClubParticipantsResponseResult> => {
+    const { clubId, cursorId } = params;
+    const res = await apiClient.get<ClubParticipantsResponse>(CLUBS.participants(clubId), {
+      params: {
+        cursorId: cursorId ?? null,
+      },
+    });
+    return res.result;
   },
   getAdminClubDetail: async (clubId: number) => {
     const res = await apiClient.get<ClubAdminDetailResponse>(CLUBS.detail(clubId));
@@ -118,4 +133,3 @@ export const clubService = {
   },
 
 };
-

--- a/src/types/groups/grouphome.ts
+++ b/src/types/groups/grouphome.ts
@@ -71,6 +71,27 @@ export interface NextMeetingResponseResult {
 
 export type NextMeetingResponse = ApiResponse<NextMeetingResponseResult>;
 
+// 5) 모임 참여자 목록: GET /api/clubs/{clubId}/participants
+export type ClubParticipantStatus = "MEMBER" | "STAFF" | "OWNER";
+
+export interface ClubParticipant {
+  clubMemberId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+  following: boolean;
+  clubMemberStatus: ClubParticipantStatus;
+  staff: boolean;
+}
+
+export interface ClubParticipantsResponseResult {
+  clubMembers: ClubParticipant[];
+  totalCount: number;
+  hasNext: boolean;
+  nextCursor: number | null;
+}
+
+export type ClubParticipantsResponse = ApiResponse<ClubParticipantsResponseResult>;
+
 
 export const CLUB_CATEGORY_CODE_TO_NUM: Record<string, number> = {
   TRAVEL: 1,


### PR DESCRIPTION
## 📌 개요 (Summary)
- 모임 상세 화면에 **모임 회원(참여자) 목록** 조회 UI를 추가했습니다.
- 총 참여 인원 표시, 운영진/모임장 배지, 구독(팔로우) 버튼, 커서 기반 무한 스크롤을 지원합니다.
- 비가입자에게는 목록 대신 "모임 회원은 가입 후에 조회 가능합니다" 안내를 노출합니다.
- 관련 이슈: #407

## 🛠 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

**상세**
- **API**: `GET /clubs/{clubId}/participants` 엔드포인트 추가 (`endpoints/Clubs.ts`)
- **서비스**: `clubService.getClubParticipants({ clubId, cursorId })` — 커서 페이지네이션 + 공통 에러 메시지 헬퍼 (`clubService.ts`)
- **쿼리**: `useClubParticipantsInfiniteQuery` 무한스크롤 훅 (`useClubhomeQueries.ts`)
- **타입**: `ClubParticipant` / `ClubParticipantsResponseResult` — 권한 구분(`OWNER`/`STAFF`/`MEMBER`), `following`, `staff`, `totalCount`, `hasNext`, `nextCursor` (`grouphome.ts`)
- **UI**: `GroupDetailClient`에 "모임 회원" 섹션 — 총 인원, 운영진 배지, 구독 버튼(`useToggleFollowMutation`), 프로필 이동, 로딩/에러/빈 상태 및 비가입자 안내
- **스타일**: 홈 모임 버튼 hover 추가 (`home_bookclub.tsx`)

## 📸 스크린샷 (Screenshots)
(모임 회원 목록 UI — 회원 있음 / 비가입자 안내 / 빈 상태 캡처 첨부)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?
