### PR TITLE
fix: 약관 페이지를 버전 경로(/support/v1/*)로 이동 (#411)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,15 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // 약관 페이지를 버전 경로(/support/v1/*)로 이동. 기존 색인/외부 링크 보존용 301 리다이렉트.
+  async redirects() {
+    return [
+      { source: "/terms", destination: "/support/v1/terms", permanent: true },
+      { source: "/privacy", destination: "/support/v1/privacy", permanent: true },
+      { source: "/third-party-consent", destination: "/support/v1/third-party-consent", permanent: true },
+      { source: "/marketing-consent", destination: "/support/v1/marketing-consent", permanent: true },
+    ];
+  },
 };
 
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -47,13 +47,25 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
     {
-      url: `${baseUrl}/privacy`,
+      url: `${baseUrl}/support/v1/terms`,
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.5,
     },
     {
-      url: `${baseUrl}/terms`,
+      url: `${baseUrl}/support/v1/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/support/v1/third-party-consent`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/support/v1/marketing-consent`,
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.5,

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -8,10 +8,10 @@ import {
 import { EXTERNAL_LINKS } from "@/constants/links";
 
 const POLICY_LINKS = [
-  { href: "/terms", label: "이용약관" },
-  { href: "/privacy", label: "개인정보처리방침" },
-  { href: "/third-party-consent", label: "개인정보 제3자 제공 동의" },
-  { href: "/marketing-consent", label: "마케팅 및 이벤트 정보 수신 동의" },
+  { href: "/support/v1/terms", label: "이용약관" },
+  { href: "/support/v1/privacy", label: "개인정보처리방침" },
+  { href: "/support/v1/third-party-consent", label: "개인정보 제3자 제공 동의" },
+  { href: "/support/v1/marketing-consent", label: "마케팅 및 이벤트 정보 수신 동의" },
 ];
 
 export const metadata: Metadata = {

--- a/src/app/support/v1/marketing-consent/page.tsx
+++ b/src/app/support/v1/marketing-consent/page.tsx
@@ -8,13 +8,13 @@ export const metadata: Metadata = {
   description:
     "책모 마케팅 및 이벤트 정보 수신 동의 안내입니다. 수신 내용, 방법, 철회 방법을 안내합니다.",
   alternates: {
-    canonical: "/marketing-consent",
+    canonical: "/support/v1/marketing-consent",
   },
   openGraph: {
     title: "책모 마케팅 및 이벤트 정보 수신 동의",
     description:
       "책모 마케팅 및 이벤트 정보 수신 동의 안내입니다. 수신 내용, 방법, 철회 방법을 안내합니다.",
-    url: "/marketing-consent",
+    url: "/support/v1/marketing-consent",
   },
 };
 

--- a/src/app/support/v1/privacy/page.tsx
+++ b/src/app/support/v1/privacy/page.tsx
@@ -10,13 +10,13 @@ export const metadata: Metadata = {
   description:
     "책모 개인정보처리방침입니다. 개인정보 수집 항목, 이용 목적, 보관 및 파기, 이용자 권리를 안내합니다.",
   alternates: {
-    canonical: "/privacy",
+    canonical: "/support/v1/privacy",
   },
   openGraph: {
     title: "책모 개인정보처리방침",
     description:
       "책모 개인정보처리방침입니다. 개인정보 수집 항목, 이용 목적, 보관 및 파기, 이용자 권리를 안내합니다.",
-    url: "/privacy",
+    url: "/support/v1/privacy",
   },
 };
 

--- a/src/app/support/v1/terms/page.tsx
+++ b/src/app/support/v1/terms/page.tsx
@@ -9,12 +9,12 @@ export const metadata: Metadata = {
   title: "이용약관",
   description: "책모 서비스 이용약관입니다.",
   alternates: {
-    canonical: "/terms",
+    canonical: "/support/v1/terms",
   },
   openGraph: {
     title: "책모 이용약관",
     description: "책모 서비스 이용약관입니다.",
-    url: "/terms",
+    url: "/support/v1/terms",
   },
 };
 

--- a/src/app/support/v1/third-party-consent/page.tsx
+++ b/src/app/support/v1/third-party-consent/page.tsx
@@ -8,13 +8,13 @@ export const metadata: Metadata = {
   description:
     "책모 개인정보 제3자 제공 동의 안내입니다. 제3자 제공 여부와 동의 거부 권리를 안내합니다.",
   alternates: {
-    canonical: "/third-party-consent",
+    canonical: "/support/v1/third-party-consent",
   },
   openGraph: {
     title: "책모 개인정보 제3자 제공 동의",
     description:
       "책모 개인정보 제3자 제공 동의 안내입니다. 제3자 제공 여부와 동의 거부 권리를 안내합니다.",
-    url: "/third-party-consent",
+    url: "/support/v1/third-party-consent",
   },
 };
 


### PR DESCRIPTION
- terms/privacy/third-party-consent/marketing-consent 4개 공개 약관을 src/app/{...} → src/app/support/v1/{...} 로 이동 (git mv, 히스토리 보존)
- 각 페이지 metadata canonical/og url을 새 경로로 갱신
- support 페이지 정책 링크 4개 + sitemap.ts(4개 모두 등재) 갱신
- next.config.ts에 구 URL → 신 URL 308 영구 리다이렉트 추가 (기존 색인/외부 링크 보존)
- /setting/terms(앱 내부 설정)와 회원가입 inline 약관은 변경 없음

## 📌 개요 (Summary)
- 변경 사항에 대한 간략한 요약을 적어주세요.
- 관련 이슈가 있다면 링크를 걸어주세요 (예: #123).

## 🛠️ 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support and consent pages now use versioned URLs under `/support/v1/`.
  * Legacy support links automatically redirect to the new locations.

* **Bug Fixes**
  * Updated site links and metadata so search engines and social previews point to the correct support pages.
  * The sitemap now reflects the new support page URLs, improving discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->