### PR TITLE
fix: 검색 화면 반응형 UI 개선

### DIFF
--- a/src/components/base-ui/Group-Search/search_clublist/search_clublist_item.tsx
+++ b/src/components/base-ui/Group-Search/search_clublist/search_clublist_item.tsx
@@ -103,9 +103,9 @@ export default function SearchClubListItem({
               className="object-cover"
             />
           </div>
-          <div className="min-w-0">
-            <div className="min-w-0">
-              <p className="subhead_2 text-Gray-7 truncate">{club.name}</p>
+          <div className="min-w-0 overflow-hidden">
+            <div className="min-w-0 overflow-hidden">
+              <p className="block w-full min-w-0 truncate subhead_2 text-Gray-7" title={club.name}>{club.name}</p>
               <div className="mt-1">
                 <ClubCategoryTags category={club.category} />
               </div>
@@ -124,8 +124,8 @@ export default function SearchClubListItem({
 
         {/* Left - Mobile */}
         <div className="t:hidden flex flex-1 flex-col min-w-0">
-          <div className="min-w-0">
-            <p className="body_1 text-Gray-7 truncate">{club.name}</p>
+          <div className="min-w-0 overflow-hidden">
+            <p className="block w-full min-w-0 truncate body_1 text-Gray-7" title={club.name}>{club.name}</p>
             <div className="mt-1">
               <ClubCategoryTags category={club.category} className="body_2_2" />
             </div>

--- a/src/components/base-ui/Group-Search/search_mybookclub.tsx
+++ b/src/components/base-ui/Group-Search/search_mybookclub.tsx
@@ -81,9 +81,10 @@ export default function Mybookclub({ groups, isLoading = false, footer, singleCo
               <div
                 key={group.id}
                 onClick={() => router.push(`/groups/${group.id}`)}
-                className="flex w-full h-[36px] t:h-[52px] py-3 px-4 items-center rounded-lg bg-white hover:brightness-98 hover:-translate-y-[1px] cursor-pointer"
+                className="flex w-full min-w-0 h-[36px] t:h-[52px] py-3 px-4 items-center overflow-hidden rounded-lg bg-white hover:brightness-98 hover:-translate-y-[1px] cursor-pointer"
+                title={group.name}
               >
-                <span className="text-Gray-7 body_1_2 t:subhead_4_1">
+                <span className="block w-full min-w-0 truncate text-Gray-7 body_1_2 t:subhead_4_1">
                   {group.name}
                 </span>
               </div>

--- a/src/components/base-ui/Group-Search/search_mybookclub.tsx
+++ b/src/components/base-ui/Group-Search/search_mybookclub.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export type GroupSummary = { id: string; name: string };
 
@@ -27,8 +27,6 @@ export default function Mybookclub({ groups, isLoading = false, footer, singleCo
 
   const [open, setOpen] = useState(false);
   const [limit, setLimit] = useState(3);
-
-  const router = useRouter();
 
   useEffect(() => {
     const apply = () => setLimit(getLimitByViewport());
@@ -78,16 +76,16 @@ export default function Mybookclub({ groups, isLoading = false, footer, singleCo
             ].join(" ")}
           >
             {displayGroups.map((group) => (
-              <div
+              <Link
                 key={group.id}
-                onClick={() => router.push(`/groups/${group.id}`)}
+                href={`/groups/${group.id}`}
                 className="flex w-full min-w-0 h-[36px] t:h-[52px] py-3 px-4 items-center overflow-hidden rounded-lg bg-white hover:brightness-98 hover:-translate-y-[1px] cursor-pointer"
                 title={group.name}
               >
                 <span className="block w-full min-w-0 truncate text-Gray-7 body_1_2 t:subhead_4_1">
                   {group.name}
                 </span>
-              </div>
+              </Link>
             ))}
           </div>
 

--- a/src/components/base-ui/Search/search_bookresult.tsx
+++ b/src/components/base-ui/Search/search_bookresult.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Image from "next/image";
+import type { MouseEvent } from "react";
 
 type SearchBookResultProps = {
   imgUrl?: string; // 없으면 booksample.svg
@@ -32,6 +33,14 @@ export default function SearchBookResult({
   const coverSrc = imgUrl && imgUrl.length > 0 ? imgUrl : "/booksample.svg";
   const clippedDetail =
     detail.length > 500 ? detail.slice(0, 500) + "..." : detail;
+  const handleLikeClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onLikeChange(!liked);
+  };
+  const handlePencilClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onPencilClick?.();
+  };
 
   return (
     <div
@@ -53,7 +62,7 @@ export default function SearchBookResult({
       </div>
 
       <div className="flex flex-1 min-w-0 items-start gap-[24px]">
-        <div className="flex flex-col min-w-0 flex-1">
+        <div className="flex flex-col min-w-0 flex-1 t:pr-12">
           <p className="text-Gray-7 subhead_3 truncate">{title}</p>
           <p className="text-Gray-4 subhead_4_1 truncate">{author}</p>
 
@@ -63,41 +72,55 @@ export default function SearchBookResult({
             {clippedDetail}
           </p>
         </div>
-
-        <div className="hidden d:flex flex-col items-end shrink-0 ml-4 ">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onLikeChange(!liked);
-            }}
-            className="w-[24px] h-[24px] shrink-0 cursor-pointer transition-transform hover:scale-[1.1]"
-          >
-            <Image
-              src={liked ? "/red_heart.svg" : "/gray_heart.svg"}
-              alt=""
-              width={24}
-              height={24}
-            />
-          </button>
-        </div>
       </div>
 
       <button
         type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onPencilClick?.();
-        }}
-        className="
-              flex absolute bottom-[20px] right-[20px] w-12 h-12 t:w-15 t:h-15 px-[10px] py-[4.167px]
-              flex-col justify-center items-center gap-[8.333px] shrink-0
-              rounded-full bg-primary-2
-              cursor-pointer active:-translate-y-[6px] active:brightness-95 hover:brightness-90
-            "
+        onClick={handleLikeClick}
+        className="absolute top-[20px] right-[20px] z-10 hidden t:flex w-[24px] h-[24px] shrink-0 cursor-pointer items-center justify-center transition-transform hover:scale-[1.1]"
+        aria-label={liked ? "좋아요 취소" : "좋아요"}
       >
-        <Image src="/pencil_icon.svg" alt="" width={20} height={20} />
+        <Image
+          src={liked ? "/red_heart.svg" : "/gray_heart.svg"}
+          alt=""
+          width={24}
+          height={24}
+        />
       </button>
+
+      <div className="absolute bottom-[20px] right-[20px] z-10 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleLikeClick}
+          className="
+                flex t:hidden w-12 h-12 px-[10px] py-[4.167px]
+                flex-col justify-center items-center gap-[8.333px] shrink-0
+                rounded-full border border-Subbrown-4 bg-white shadow-[0_2px_4px_rgba(0,0,0,0.08)]
+                cursor-pointer active:-translate-y-[6px] active:brightness-95 hover:brightness-98
+              "
+          aria-label={liked ? "좋아요 취소" : "좋아요"}
+        >
+          <Image
+            src={liked ? "/red_heart.svg" : "/gray_heart.svg"}
+            alt=""
+            width={24}
+            height={24}
+          />
+        </button>
+
+        <button
+          type="button"
+          onClick={handlePencilClick}
+          className="
+                flex w-12 h-12 t:w-15 t:h-15 px-[10px] py-[4.167px]
+                flex-col justify-center items-center gap-[8.333px] shrink-0
+                rounded-full bg-primary-2
+                cursor-pointer active:-translate-y-[6px] active:brightness-95 hover:brightness-90
+              "
+        >
+          <Image src="/pencil_icon.svg" alt="" width={20} height={20} />
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 변경사항
- 모바일/태블릿에서 긴 모임명이 카드 밖으로 넘치지 않도록 말줄임 처리했습니다.
- 내 모임 목록의 긴 모임명도 박스 내부에서 안전하게 표시되도록 수정했습니다.
- 책 검색 결과에서 모바일 화면일 때 좋아요 버튼이 사라지지 않도록 책이야기 작성 버튼 옆에 플로팅 배치했습니다.
- 태블릿 이상에서는 좋아요 버튼을 카드 우측 상단에 유지했습니다.

## 관련 이슈
- Closes #이슈번호

## 체크리스트
- [x] 타입 체크 완료 (`npx tsc --noEmit --pretty false`)
- [x] 수정 파일 lint 완료
- [x] 공백/whitespace 체크 완료 (`git diff --check`)

## 특이사항
- 책장 상세 화면은 이번 작업 범위에서 제외했습니다.