### PR TITLE
Feat/442 terms api

### DIFF
--- a/src/app/(public)/signup/[step]/SignupStepPageClient.tsx
+++ b/src/app/(public)/signup/[step]/SignupStepPageClient.tsx
@@ -52,7 +52,7 @@ export default function SignupStepPageClient() {
                 setEmail(newEmail);
             }
 
-            if (step === "terms" || step === "email" || step === "password") {
+            if (step === "email" || step === "password") {
                 router.replace(PROFILE_COMPLETION_ROUTE);
             }
         }

--- a/src/components/base-ui/Join/steps/PasswordEntry/PasswordEntry.tsx
+++ b/src/components/base-ui/Join/steps/PasswordEntry/PasswordEntry.tsx
@@ -17,7 +17,7 @@ interface PasswordEntryProps {
 }
 
 const PasswordEntry: React.FC<PasswordEntryProps> = ({ onNext }) => {
-  const { email, password, setPassword, confirmPassword, setConfirmPassword, showToast } = useSignup();
+  const { email, password, setPassword, confirmPassword, setConfirmPassword, agreements, showToast } = useSignup();
   const [isLoading, setIsLoading] = React.useState(false);
 
   const isMatch =
@@ -28,7 +28,11 @@ const PasswordEntry: React.FC<PasswordEntryProps> = ({ onNext }) => {
 
     setIsLoading(true);
     try {
-      await authService.signup({ email, password });
+      const agreedTermsIds = Object.entries(agreements)
+        .filter(([, agreed]) => agreed)
+        .map(([id]) => Number(id));
+
+      await authService.signup({ email, password, agreedTermsIds });
       await authService.login({ identifier: email, password });
       onNext();
     } catch (error: unknown) {

--- a/src/components/base-ui/Join/steps/TermsAgreement/TermsAgreement.tsx
+++ b/src/components/base-ui/Join/steps/TermsAgreement/TermsAgreement.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import JoinLayout from "@/components/base-ui/Join/JoinLayout";
 import JoinButton from "@/components/base-ui/Join/JoinButton";
@@ -11,19 +11,14 @@ import { TERMS_DATA as TERMS_OF_USE_DATA } from "@/constants/setting/terms";
 import { THIRD_PARTY_DATA } from "@/constants/setting/thirdParty";
 import { MARKETING_DATA } from "@/constants/setting/marketing";
 import { useSignup } from "@/contexts/SignupContext";
-
-const TERMS_DATA = [
-  { id: "servicePrivacy", label: "서비스 이용을 위한 필수 개인정보 수집·이용 동의 (필수)", required: true },
-  { id: "termsOfUse", label: "책모 이용약관 동의 (필수)", required: true },
-  { id: "thirdParty", label: "개인정보 제3자 제공 동의 (선택)", required: false },
-  { id: "marketing", label: "마케팅 및 이벤트 정보 수신 동의 (선택)", required: false },
-];
+import { memberService } from "@/services/memberService";
+import { Term } from "@/types/auth";
 
 const TERMS_CONTENT_MAP: Record<string, { title: string; content: string | string[] }[]> = {
-  servicePrivacy: PRIVACY_DATA,
-  termsOfUse: TERMS_OF_USE_DATA,
-  thirdParty: THIRD_PARTY_DATA,
-  marketing: MARKETING_DATA,
+  PRIVACY_COLLECTION: PRIVACY_DATA,
+  SERVICE_TERMS: TERMS_OF_USE_DATA,
+  THIRD_PARTY_PROVISION: THIRD_PARTY_DATA,
+  MARKETING: MARKETING_DATA,
 };
 
 interface TermsAgreementProps {
@@ -31,33 +26,117 @@ interface TermsAgreementProps {
 }
 
 const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
-  const { agreements, setAgreements } = useSignup();
-  const [selectedTermId, setSelectedTermId] = useState<string | null>(null);
+  const { agreements, setAgreements, isSocial, showToast } = useSignup();
+  const [termsData, setTermsData] = useState<Term[]>([]);
+  const [selectedTermId, setSelectedTermId] = useState<number | null>(null);
+  const [isFetching, setIsFetching] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const allAgreed = TERMS_DATA.every((term) => agreements[term.id]);
-  const isButtonEnabled = TERMS_DATA.filter((term) => term.required).every(
+  useEffect(() => {
+    const fetchTerms = async () => {
+      try {
+        const { terms } = await memberService.getTerms();
+        setTermsData(terms);
+
+        if (isSocial) {
+          try {
+            const myTerms = await memberService.getMyTerms();
+            
+            // 필수 약관에 이미 동의했다면 바로 넘어갑니다
+            if (!myTerms.requiresRequiredAgreement) {
+              onNext();
+              return;
+            }
+
+            const newAgreements: Record<number, boolean> = {};
+            myTerms.terms.forEach(term => {
+              newAgreements[term.id] = term.agreed;
+            });
+            setAgreements(newAgreements);
+          } catch (e) {
+            console.error("Failed to fetch my terms", e);
+            // Ignore error, user will start fresh
+          }
+        } else {
+          // Initialize agreements if not already set
+          if (Object.keys(agreements).length === 0) {
+            const initialAgreements: Record<number, boolean> = {};
+            terms.forEach(term => {
+              initialAgreements[term.id] = false;
+            });
+            setAgreements(initialAgreements);
+          }
+        }
+      } catch (error) {
+        showToast("약관을 불러오는데 실패했습니다.");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchTerms();
+  }, [isSocial, onNext, setAgreements, showToast]);
+
+  const allAgreed = termsData.length > 0 && termsData.every((term) => agreements[term.id]);
+  const isButtonEnabled = termsData.length > 0 && termsData.filter((term) => term.required).every(
     (term) => agreements[term.id]
   );
 
-  const handleNext = () => {
-    onNext();
+  const handleNext = async () => {
+    if (!isButtonEnabled || isSubmitting) return;
+
+    if (isSocial) {
+      setIsSubmitting(true);
+      try {
+        const payload = {
+          agreements: termsData.map((term) => ({
+            termsId: term.id,
+            agreed: !!agreements[term.id],
+          })),
+        };
+        await memberService.saveMyTerms(payload);
+        onNext();
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          showToast(error.message || "약관 동의 저장에 실패했습니다.");
+        } else {
+          showToast("약관 동의 저장에 실패했습니다.");
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    } else {
+      onNext();
+    }
   };
 
-  const handleAgreementChange = (id: string, checked: boolean) => {
+  const handleAgreementChange = (id: number, checked: boolean) => {
     setAgreements({ ...agreements, [id]: checked });
   };
 
   const handleAllAgreementChange = () => {
     const checked = !allAgreed;
-    const newAgreements = TERMS_DATA.reduce((acc, term) => {
+    const newAgreements = termsData.reduce((acc, term) => {
       acc[term.id] = checked;
       return acc;
-    }, {} as Record<string, boolean>);
+    }, {} as Record<number, boolean>);
     setAgreements(newAgreements);
   };
 
-  if (selectedTermId) {
-    const termData = TERMS_CONTENT_MAP[selectedTermId];
+  if (isFetching) {
+    return (
+      <JoinLayout title="약관 동의">
+        <div className="flex flex-col items-center w-full">
+          <p className="text-Gray-5">약관을 불러오는 중입니다...</p>
+        </div>
+      </JoinLayout>
+    );
+  }
+
+  if (selectedTermId !== null) {
+    const selectedTerm = termsData.find(t => t.id === selectedTermId);
+    const termDataContent = selectedTerm ? TERMS_CONTENT_MAP[selectedTerm.termsType] : null;
+
     return (
       <JoinLayout title="약관 동의">
         <div className="flex flex-col items-center w-full">
@@ -84,24 +163,42 @@ const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
             <div className="flex flex-col w-full h-full overflow-hidden">
               <div className="flex-1 overflow-y-auto px-[8px] t:px-[64px] custom-scrollbar">
                 <div className="flex flex-col w-full gap-6">
-                  {termData.map((term, i) => (
-                    <div key={i} className="flex flex-col gap-2">
-                      <h3 className="text-[16px] font-semibold text-Gray-7">{term.title}</h3>
-                      {Array.isArray(term.content) ? (
-                        <ul className="flex list-disc flex-col gap-1 pl-5 text-[14px] text-Gray-5">
-                          {term.content.map((item, idx) => (
-                            <li key={idx}>{item}</li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <div className="flex flex-col gap-1 text-[14px] text-Gray-5">
-                          {term.content.split("\n").map((line, idx) => (
-                            <p key={idx}>{line.trim()}</p>
-                          ))}
-                        </div>
-                      )}
+                  {termDataContent ? (
+                    termDataContent.map((term, i) => (
+                      <div key={i} className="flex flex-col gap-2">
+                        <h3 className="text-[16px] font-semibold text-Gray-7">{term.title}</h3>
+                        {Array.isArray(term.content) ? (
+                          <ul className="flex list-disc flex-col gap-1 pl-5 text-[14px] text-Gray-5">
+                            {term.content.map((item, idx) => (
+                              <li key={idx}>{item}</li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <div className="flex flex-col gap-1 text-[14px] text-Gray-5">
+                            {term.content.split("\n").map((line, idx) => (
+                              <p key={idx}>{line.trim()}</p>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))
+                  ) : (
+                    <div className="flex flex-col items-center justify-center h-full text-Gray-5">
+                      <p>약관 내용을 불러올 수 없습니다.</p>
                     </div>
-                  ))}
+                  )}
+                  {selectedTerm?.termUrl && (
+                    <div className="flex justify-center w-full mt-4 pb-4">
+                      <a 
+                        href={selectedTerm.termUrl} 
+                        target="_blank" 
+                        rel="noopener noreferrer" 
+                        className="text-[14px] text-[#BBAA9B] underline hover:text-[#9c8e80]"
+                      >
+                        새 창으로 보기
+                      </a>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -127,7 +224,7 @@ const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
         <div className="flex flex-col justify-center w-[270px] h-[297px] px-[24px] gap-[24px] rounded-[12px] bg-background t:w-[584px] t:h-[386px] t:px-[40px] t:pt-[24px] t:pb-[36px]">
           {/* 개별 약관 리스트 */}
           <div className="flex flex-col gap-[20px]">
-            {TERMS_DATA.map((term) => (
+            {termsData.map((term) => (
               <div
                 key={term.id}
                 className="flex items-center justify-between w-full gap-[12px]"
@@ -136,7 +233,7 @@ const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
                   className="flex-1 text-[#353535] font-sans text-[12px] font-normal leading-[145%] tracking-[-0.012px] t:text-[19.861px] t:leading-[15.605px] cursor-pointer hover:underline pr-[4px]"
                   onClick={() => setSelectedTermId(term.id)}
                 >
-                  {term.label}
+                  {term.title}
                 </span>
                 <div
                   className="relative w-[15px] h-[15px] shrink-0 t:w-[24px] t:h-[24px] cursor-pointer"
@@ -178,11 +275,11 @@ const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
         </div>
 
         <JoinButton
-          disabled={!isButtonEnabled}
+          disabled={!isButtonEnabled || isSubmitting}
           onClick={handleNext}
           className="w-[270px] t:w-[526px]"
         >
-          다음
+          {isSubmitting ? "처리 중..." : "다음"}
         </JoinButton>
       </div>
     </JoinLayout>

--- a/src/components/base-ui/Join/steps/TermsAgreement/TermsAgreement.tsx
+++ b/src/components/base-ui/Join/steps/TermsAgreement/TermsAgreement.tsx
@@ -2,126 +2,31 @@
 
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import JoinLayout from "@/components/base-ui/Join/JoinLayout";
 import JoinButton from "@/components/base-ui/Join/JoinButton";
-import { PRIVACY_DATA } from "@/constants/setting/privacy";
-import { TERMS_DATA as TERMS_OF_USE_DATA } from "@/constants/setting/terms";
-import { THIRD_PARTY_DATA } from "@/constants/setting/thirdParty";
-import { MARKETING_DATA } from "@/constants/setting/marketing";
-import { useSignup } from "@/contexts/SignupContext";
-import { memberService } from "@/services/memberService";
-import { Term } from "@/types/auth";
-
-const TERMS_CONTENT_MAP: Record<string, { title: string; content: string | string[] }[]> = {
-  PRIVACY_COLLECTION: PRIVACY_DATA,
-  SERVICE_TERMS: TERMS_OF_USE_DATA,
-  THIRD_PARTY_PROVISION: THIRD_PARTY_DATA,
-  MARKETING: MARKETING_DATA,
-};
+import { useTermsAgreement } from "./useTermsAgreement";
+import TermsDetailModal from "./TermsDetailModal";
 
 interface TermsAgreementProps {
   onNext: () => void;
 }
 
 const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
-  const { agreements, setAgreements, isSocial, showToast } = useSignup();
-  const [termsData, setTermsData] = useState<Term[]>([]);
+  const {
+    termsData,
+    agreements,
+    isFetching,
+    isSubmitting,
+    isButtonEnabled,
+    allAgreed,
+    handleAgreementChange,
+    handleAllAgreementChange,
+    handleNext,
+  } = useTermsAgreement(onNext);
+
   const [selectedTermId, setSelectedTermId] = useState<number | null>(null);
-  const [isFetching, setIsFetching] = useState(true);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  useEffect(() => {
-    const fetchTerms = async () => {
-      try {
-        const { terms } = await memberService.getTerms();
-        setTermsData(terms);
-
-        if (isSocial) {
-          try {
-            const myTerms = await memberService.getMyTerms();
-            
-            // 필수 약관에 이미 동의했다면 바로 넘어갑니다
-            if (!myTerms.requiresRequiredAgreement) {
-              onNext();
-              return;
-            }
-
-            const newAgreements: Record<number, boolean> = {};
-            myTerms.terms.forEach(term => {
-              newAgreements[term.id] = term.agreed;
-            });
-            setAgreements(newAgreements);
-          } catch (e) {
-            console.error("Failed to fetch my terms", e);
-            // Ignore error, user will start fresh
-          }
-        } else {
-          // Initialize agreements if not already set
-          if (Object.keys(agreements).length === 0) {
-            const initialAgreements: Record<number, boolean> = {};
-            terms.forEach(term => {
-              initialAgreements[term.id] = false;
-            });
-            setAgreements(initialAgreements);
-          }
-        }
-      } catch (error) {
-        showToast("약관을 불러오는데 실패했습니다.");
-      } finally {
-        setIsFetching(false);
-      }
-    };
-
-    fetchTerms();
-  }, [isSocial, onNext, setAgreements, showToast]);
-
-  const allAgreed = termsData.length > 0 && termsData.every((term) => agreements[term.id]);
-  const isButtonEnabled = termsData.length > 0 && termsData.filter((term) => term.required).every(
-    (term) => agreements[term.id]
-  );
-
-  const handleNext = async () => {
-    if (!isButtonEnabled || isSubmitting) return;
-
-    if (isSocial) {
-      setIsSubmitting(true);
-      try {
-        const payload = {
-          agreements: termsData.map((term) => ({
-            termsId: term.id,
-            agreed: !!agreements[term.id],
-          })),
-        };
-        await memberService.saveMyTerms(payload);
-        onNext();
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          showToast(error.message || "약관 동의 저장에 실패했습니다.");
-        } else {
-          showToast("약관 동의 저장에 실패했습니다.");
-        }
-      } finally {
-        setIsSubmitting(false);
-      }
-    } else {
-      onNext();
-    }
-  };
-
-  const handleAgreementChange = (id: number, checked: boolean) => {
-    setAgreements({ ...agreements, [id]: checked });
-  };
-
-  const handleAllAgreementChange = () => {
-    const checked = !allAgreed;
-    const newAgreements = termsData.reduce((acc, term) => {
-      acc[term.id] = checked;
-      return acc;
-    }, {} as Record<number, boolean>);
-    setAgreements(newAgreements);
-  };
 
   if (isFetching) {
     return (
@@ -134,87 +39,22 @@ const TermsAgreement: React.FC<TermsAgreementProps> = ({ onNext }) => {
   }
 
   if (selectedTermId !== null) {
-    const selectedTerm = termsData.find(t => t.id === selectedTermId);
-    const termDataContent = selectedTerm ? TERMS_CONTENT_MAP[selectedTerm.termsType] : null;
+    const selectedTerm = termsData.find((t) => t.id === selectedTermId);
 
-    return (
-      <JoinLayout title="약관 동의">
-        <div className="flex flex-col items-center w-full">
-          {/* Detailed Box: Responsive width and padding */}
-          <div className="relative flex flex-col items-center justify-between w-[272px] t:w-[654px] h-[580px] t:h-[645px] max-h-[80vh] px-[12px] py-[30px] t:py-[80px] rounded-[8px] border border-[#BBAA9B] bg-white shadow-[2px_4px_4px_0_rgba(0,0,0,0.25)] transition-all">
-            <button
-              onClick={() => setSelectedTermId(null)}
-              className="absolute right-[12px] top-[12px] w-[24px] h-[24px] flex items-center justify-center text-Gray-4 hover:text-Gray-6 transition-colors z-10"
-            >
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </button>
-            <div className="flex flex-col w-full h-full overflow-hidden">
-              <div className="flex-1 overflow-y-auto px-[8px] t:px-[64px] custom-scrollbar">
-                <div className="flex flex-col w-full gap-6">
-                  {termDataContent ? (
-                    termDataContent.map((term, i) => (
-                      <div key={i} className="flex flex-col gap-2">
-                        <h3 className="text-[16px] font-semibold text-Gray-7">{term.title}</h3>
-                        {Array.isArray(term.content) ? (
-                          <ul className="flex list-disc flex-col gap-1 pl-5 text-[14px] text-Gray-5">
-                            {term.content.map((item, idx) => (
-                              <li key={idx}>{item}</li>
-                            ))}
-                          </ul>
-                        ) : (
-                          <div className="flex flex-col gap-1 text-[14px] text-Gray-5">
-                            {term.content.split("\n").map((line, idx) => (
-                              <p key={idx}>{line.trim()}</p>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    ))
-                  ) : (
-                    <div className="flex flex-col items-center justify-center h-full text-Gray-5">
-                      <p>약관 내용을 불러올 수 없습니다.</p>
-                    </div>
-                  )}
-                  {selectedTerm?.termUrl && (
-                    <div className="flex justify-center w-full mt-4 pb-4">
-                      <a 
-                        href={selectedTerm.termUrl} 
-                        target="_blank" 
-                        rel="noopener noreferrer" 
-                        className="text-[14px] text-[#BBAA9B] underline hover:text-[#9c8e80]"
-                      >
-                        새 창으로 보기
-                      </a>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-            <JoinButton
-              onClick={() => {
-                handleAgreementChange(selectedTermId, true);
-                setSelectedTermId(null);
-              }}
-              className="w-full t:w-[526px] h-[48px] px-[16px] py-[12px] mt-[20px] t:mt-[24px] shrink-0 font-sans text-[14px] font-semibold leading-[145%] tracking-[-0.014px]"
-            >
-              동의
-            </JoinButton>
-          </div>
-        </div>
-      </JoinLayout>
-    );
+    if (selectedTerm) {
+      return (
+        <JoinLayout title="약관 동의">
+          <TermsDetailModal
+            selectedTerm={selectedTerm}
+            onClose={() => setSelectedTermId(null)}
+            onAgree={() => {
+              handleAgreementChange(selectedTermId, true);
+              setSelectedTermId(null);
+            }}
+          />
+        </JoinLayout>
+      );
+    }
   }
 
   return (

--- a/src/components/base-ui/Join/steps/TermsAgreement/TermsDetailModal.tsx
+++ b/src/components/base-ui/Join/steps/TermsAgreement/TermsDetailModal.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import JoinButton from "@/components/base-ui/Join/JoinButton";
+import { PRIVACY_DATA } from "@/constants/setting/privacy";
+import { TERMS_DATA as TERMS_OF_USE_DATA } from "@/constants/setting/terms";
+import { THIRD_PARTY_DATA } from "@/constants/setting/thirdParty";
+import { MARKETING_DATA } from "@/constants/setting/marketing";
+import { Term } from "@/types/auth";
+
+const TERMS_CONTENT_MAP: Record<string, { title: string; content: string | string[] }[]> = {
+  PRIVACY_COLLECTION: PRIVACY_DATA,
+  SERVICE_TERMS: TERMS_OF_USE_DATA,
+  THIRD_PARTY_PROVISION: THIRD_PARTY_DATA,
+  MARKETING: MARKETING_DATA,
+};
+
+interface TermsDetailModalProps {
+  selectedTerm: Term;
+  onClose: () => void;
+  onAgree: () => void;
+}
+
+const TermsDetailModal: React.FC<TermsDetailModalProps> = ({ selectedTerm, onClose, onAgree }) => {
+  const termDataContent = TERMS_CONTENT_MAP[selectedTerm.termsType];
+
+  return (
+    <div className="flex flex-col items-center w-full">
+      <div className="relative flex flex-col items-center justify-between w-[272px] t:w-[654px] h-[580px] t:h-[645px] max-h-[80vh] px-[12px] py-[30px] t:py-[80px] rounded-[8px] border border-[#BBAA9B] bg-white shadow-[2px_4px_4px_0_rgba(0,0,0,0.25)] transition-all">
+        <button
+          onClick={onClose}
+          className="absolute right-[12px] top-[12px] w-[24px] h-[24px] flex items-center justify-center text-Gray-4 hover:text-Gray-6 transition-colors z-10"
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+        <div className="flex flex-col w-full h-full overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-[8px] t:px-[64px] custom-scrollbar">
+            <div className="flex flex-col w-full gap-6">
+              {termDataContent ? (
+                termDataContent.map((term, i) => (
+                  <div key={i} className="flex flex-col gap-2">
+                    <h3 className="text-[16px] font-semibold text-Gray-7">{term.title}</h3>
+                    {Array.isArray(term.content) ? (
+                      <ul className="flex list-disc flex-col gap-1 pl-5 text-[14px] text-Gray-5">
+                        {term.content.map((item, idx) => (
+                          <li key={idx}>{item}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="flex flex-col gap-1 text-[14px] text-Gray-5">
+                        {term.content.split("\n").map((line, idx) => (
+                          <p key={idx}>{line.trim()}</p>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-Gray-5">
+                  <p>약관 내용을 불러올 수 없습니다.</p>
+                </div>
+              )}
+              {selectedTerm.termUrl && (
+                <div className="flex justify-center w-full mt-4 pb-4">
+                  <a 
+                    href={selectedTerm.termUrl} 
+                    target="_blank" 
+                    rel="noopener noreferrer" 
+                    className="text-[14px] text-[#BBAA9B] underline hover:text-[#9c8e80]"
+                  >
+                    새 창으로 보기
+                  </a>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+        <JoinButton
+          onClick={onAgree}
+          className="w-full t:w-[526px] h-[48px] px-[16px] py-[12px] mt-[20px] t:mt-[24px] shrink-0 font-sans text-[14px] font-semibold leading-[145%] tracking-[-0.014px]"
+        >
+          동의
+        </JoinButton>
+      </div>
+    </div>
+  );
+};
+
+export default TermsDetailModal;

--- a/src/components/base-ui/Join/steps/TermsAgreement/useTermsAgreement.ts
+++ b/src/components/base-ui/Join/steps/TermsAgreement/useTermsAgreement.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect, useCallback } from "react";
+import { memberService } from "@/services/memberService";
+import { Term } from "@/types/auth";
+import { useSignup } from "@/contexts/SignupContext";
+
+export const useTermsAgreement = (onNext: () => void) => {
+  const { agreements, setAgreements, isSocial, showToast } = useSignup();
+  const [termsData, setTermsData] = useState<Term[]>([]);
+  const [isFetching, setIsFetching] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchTerms = async () => {
+      try {
+        const { terms } = await memberService.getTerms();
+        setTermsData(terms);
+
+        if (isSocial) {
+          try {
+            const myTerms = await memberService.getMyTerms();
+            
+            if (!myTerms.requiresRequiredAgreement) {
+              onNext();
+              return;
+            }
+
+            const newAgreements: Record<number, boolean> = {};
+            myTerms.terms.forEach(term => {
+              newAgreements[term.id] = term.agreed;
+            });
+            setAgreements(newAgreements);
+          } catch (e) {
+            console.error("Failed to fetch my terms", e);
+          }
+        } else {
+          if (Object.keys(agreements).length === 0) {
+            const initialAgreements: Record<number, boolean> = {};
+            terms.forEach(term => {
+              initialAgreements[term.id] = false;
+            });
+            setAgreements(initialAgreements);
+          }
+        }
+      } catch (error) {
+        showToast("약관을 불러오는데 실패했습니다.");
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchTerms();
+  }, [isSocial, onNext, setAgreements, showToast]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const allAgreed = termsData.length > 0 && termsData.every((term) => agreements[term.id]);
+  const isButtonEnabled = termsData.length > 0 && termsData.filter((term) => term.required).every(
+    (term) => agreements[term.id]
+  );
+
+  const handleNext = useCallback(async () => {
+    if (!isButtonEnabled || isSubmitting) return;
+
+    if (isSocial) {
+      setIsSubmitting(true);
+      try {
+        const payload = {
+          agreements: termsData.map((term) => ({
+            termsId: term.id,
+            agreed: !!agreements[term.id],
+          })),
+        };
+        await memberService.saveMyTerms(payload);
+        onNext();
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          showToast(error.message || "약관 동의 저장에 실패했습니다.");
+        } else {
+          showToast("약관 동의 저장에 실패했습니다.");
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    } else {
+      onNext();
+    }
+  }, [isButtonEnabled, isSubmitting, isSocial, termsData, agreements, onNext, showToast]);
+
+  const handleAgreementChange = useCallback((id: number, checked: boolean) => {
+    setAgreements({ ...agreements, [id]: checked });
+  }, [agreements, setAgreements]);
+
+  const handleAllAgreementChange = useCallback(() => {
+    const checked = !allAgreed;
+    const newAgreements = termsData.reduce((acc, term) => {
+      acc[term.id] = checked;
+      return acc;
+    }, {} as Record<number, boolean>);
+    setAgreements(newAgreements);
+  }, [allAgreed, termsData, setAgreements]);
+
+  return {
+    termsData,
+    agreements,
+    isFetching,
+    isSubmitting,
+    isButtonEnabled,
+    allAgreed,
+    handleAgreementChange,
+    handleAllAgreementChange,
+    handleNext,
+  };
+};

--- a/src/components/base-ui/Join/steps/TermsAgreement/useTermsAgreement.ts
+++ b/src/components/base-ui/Join/steps/TermsAgreement/useTermsAgreement.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { memberService } from "@/services/memberService";
 import { Term } from "@/types/auth";
 import { useSignup } from "@/contexts/SignupContext";
@@ -8,19 +8,25 @@ export const useTermsAgreement = (onNext: () => void) => {
   const [termsData, setTermsData] = useState<Term[]>([]);
   const [isFetching, setIsFetching] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasFetchedRef = useRef(false);
 
   useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+
+    let isMounted = true;
+
     const fetchTerms = async () => {
       try {
         const { terms } = await memberService.getTerms();
-        setTermsData(terms);
+        if (isMounted) setTermsData(terms);
 
         if (isSocial) {
           try {
             const myTerms = await memberService.getMyTerms();
             
             if (!myTerms.requiresRequiredAgreement) {
-              onNext();
+              if (isMounted) onNext();
               return;
             }
 
@@ -28,9 +34,10 @@ export const useTermsAgreement = (onNext: () => void) => {
             myTerms.terms.forEach(term => {
               newAgreements[term.id] = term.agreed;
             });
-            setAgreements(newAgreements);
+            if (isMounted) setAgreements(newAgreements);
           } catch (e) {
             console.error("Failed to fetch my terms", e);
+            throw e; // 에러를 밖으로 던져 UI에서 처리하도록 함
           }
         } else {
           if (Object.keys(agreements).length === 0) {
@@ -38,18 +45,22 @@ export const useTermsAgreement = (onNext: () => void) => {
             terms.forEach(term => {
               initialAgreements[term.id] = false;
             });
-            setAgreements(initialAgreements);
+            if (isMounted) setAgreements(initialAgreements);
           }
         }
       } catch (error) {
-        showToast("약관을 불러오는데 실패했습니다.");
+        if (isMounted) showToast("약관을 불러오는데 실패했습니다.");
       } finally {
-        setIsFetching(false);
+        if (isMounted) setIsFetching(false);
       }
     };
 
     fetchTerms();
-  }, [isSocial, onNext, setAgreements, showToast]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isSocial, onNext, setAgreements, showToast, agreements]); // 이제 agreements를 의존성 배열에 넣어도 초기 호출 방어가 됨
 
   const allAgreed = termsData.length > 0 && termsData.every((term) => agreements[term.id]);
   const isButtonEnabled = termsData.length > 0 && termsData.filter((term) => term.required).every(

--- a/src/contexts/SignupContext.tsx
+++ b/src/contexts/SignupContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useState, ReactNode, useCallback, use
 
 interface SignupState {
     // Terms
-    agreements: Record<string, boolean>;
+    agreements: Record<number, boolean>;
 
     // Email
     email: string;
@@ -36,7 +36,7 @@ interface SignupState {
 }
 
 interface SignupActions {
-    setAgreements: (agreements: Record<string, boolean>) => void;
+    setAgreements: (agreements: Record<number, boolean>) => void;
     setEmail: (email: string) => void;
     setVerificationCode: (code: string) => void;
     setIsVerified: (verified: boolean) => void;

--- a/src/lib/api/endpoints/member.ts
+++ b/src/lib/api/endpoints/member.ts
@@ -23,4 +23,6 @@ export const MEMBER_ENDPOINTS = {
     GET_LOGIN_STATUS: `${API_BASE_URL}/members/me/login-status`,
     BLOCK: (nickname: string) => `${API_BASE_URL}/members/${encodeURIComponent(nickname)}/block`,
     GET_MY_BLOCKS: `${API_BASE_URL}/members/me/blocks`,
+    TERMS: `${API_BASE_URL}/terms`,
+    MY_TERMS: `${API_BASE_URL}/members/me/terms`,
 };

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -2,8 +2,7 @@ import { apiClient } from "@/lib/api/client";
 import { MEMBER_ENDPOINTS } from "@/lib/api/endpoints/member";
 import { RecommendResponse, UpdateProfileRequest, UpdatePasswordRequest, ProfileResponse, OtherProfileResponse, FollowListResponse, FollowCountResponse, FindEmailRequest, FindEmailResponse, LoginStatusResponse, UpdateEmailRequest, BlockListResponse } from "@/types/member";
 import { ReportRequest, MyReportList } from "@/types/report";
-import { ApiResponse } from "@/types/auth";
-
+import { ApiResponse, TermsResponse, MemberTermsStatus, UpdateAgreementsRequest } from "@/types/auth";
 export const memberService = {
     getRecommendedMembers: async (): Promise<RecommendResponse> => {
         const response = await apiClient.get<ApiResponse<RecommendResponse>>(
@@ -185,5 +184,32 @@ export const memberService = {
             throw new Error(response.message || "차단 목록을 불러오는 데 실패했습니다.");
         }
         return response.result!;
+    },
+    getTerms: async (): Promise<TermsResponse> => {
+        const response = await apiClient.get<ApiResponse<TermsResponse>>(
+            MEMBER_ENDPOINTS.TERMS
+        );
+        if (!response.isSuccess) {
+            throw new Error(response.message || "약관을 불러오는 데 실패했습니다.");
+        }
+        return response.result!;
+    },
+    getMyTerms: async (): Promise<MemberTermsStatus> => {
+        const response = await apiClient.get<ApiResponse<MemberTermsStatus>>(
+            MEMBER_ENDPOINTS.MY_TERMS
+        );
+        if (!response.isSuccess) {
+            throw new Error(response.message || "내 약관 동의 상태를 불러오는 데 실패했습니다.");
+        }
+        return response.result!;
+    },
+    saveMyTerms: async (data: UpdateAgreementsRequest): Promise<void> => {
+        const response = await apiClient.post<ApiResponse<unknown>>(
+            MEMBER_ENDPOINTS.MY_TERMS,
+            data
+        );
+        if (!response.isSuccess) {
+            throw new Error(response.message || "약관 동의 상태를 저장하는 데 실패했습니다.");
+        }
     },
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -40,4 +40,34 @@ export interface AdditionalInfo {
 export interface SignupForm {
   email: string;
   password: string;
+  agreedTermsIds: number[];
+}
+
+export interface Term {
+  id: number;
+  termsType: string;
+  title: string;
+  termUrl: string;
+  version: number;
+  required: boolean;
+}
+
+export interface TermsResponse {
+  terms: Term[];
+}
+
+export interface MemberTerm extends Term {
+  agreed: boolean;
+}
+
+export interface MemberTermsStatus {
+  requiresRequiredAgreement: boolean;
+  terms: MemberTerm[];
+}
+
+export interface UpdateAgreementsRequest {
+  agreements: {
+    termsId: number;
+    agreed: boolean;
+  }[];
 }

--- a/src/utils/profileCompletion.ts
+++ b/src/utils/profileCompletion.ts
@@ -1,9 +1,10 @@
 import { User } from "@/types/auth";
 
-export const PROFILE_COMPLETION_BASE_ROUTE = "/signup/profile?isSocial=true";
+export const PROFILE_COMPLETION_BASE_ROUTE = "/signup/terms?isSocial=true";
 export const PROFILE_COMPLETION_ROUTE = `${PROFILE_COMPLETION_BASE_ROUTE}&profileRequired=true`;
 
 const PROFILE_COMPLETION_PATHS = new Set([
+  "/signup/terms",
   "/signup/profile",
   "/signup/profile-image",
 ]);


### PR DESCRIPTION
## 📌 개요 (Summary)
- **백엔드 약관 API 명세 변경에 따른 프론트엔드 연동 및 아키텍처 개선 작업**입니다.
- **주요 목적**: 
  - 일반 가입과 소셜 가입 각각에 대해 약관 동의 API를 다르게 태우도록 분기 처리
  - 기존 약관 컴포넌트를 SOLID 및 SoC 원칙에 따라 순수 뷰(View)와 비즈니스 훅(Hook)으로 분리 (리팩토링)
  - 약관 내용 원문을 별도 탭에서 확인할 수 있는 "새 창으로 보기" 기능 추가
- 관련 이슈: `#442` *(필요에 따라 실제 이슈 번호로 수정해 주세요)*

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

### 상세 변경 사항
1. **API 및 타입 업데이트**
   - `GET /api/v1/terms`, `GET /api/v1/members/me/terms`, `POST /api/v1/members/me/terms` 명세를 반영한 DTO 타입 정의 추가.
   - `memberService.ts`에 통신 메서드 구현.

2. **UI 및 비즈니스 로직의 완벽한 분리 (SoC 원칙 준수 리팩토링)**
   - 200줄이 넘어가던 기존 `TermsAgreement.tsx`를 아래와 같이 3분할 했습니다.
     - **`useTermsAgreement.ts`**: API 패칭, 상태 관리, 라우팅 조건 등 비즈니스 로직 전담. (Custom Hook)
     - **`TermsDetailModal.tsx`**: 긴 약관 텍스트(상수)와 '새 창으로 보기' 버튼을 렌더링하는 전용 UI 컴포넌트.
     - **`TermsAgreement.tsx`**: 위 로직과 UI를 결합하고 체크리스트 껍데기만 제공하는 Container 형태.

3. **소셜 로그인 온보딩 라우팅 분기 처리**
   - 소셜 로그인 직후 "프로필 화면"이 아닌 "약관 화면"(`/signup/terms?isSocial=true`)으로 우선 진입하도록 라우팅 우회 로직 추가.
   - 필수 약관이 모두 동의된 유저라면 약관 화면 렌더링을 생략하고 자동으로 다음 단계로 건너뛰도록(Skip) 사용자 경험 개선.

### 🗺️ 컴포넌트 및 로직 흐름도 (Architecture Flow)
이번에 수정된 약관 동의 프로세스에 대한 전체 흐름도입니다.

<img width="473" height="765" alt="image" src="https://github.com/user-attachments/assets/5e826f0d-4618-4abe-a4ea-5f72eeaa0200" />


## 📸 스크린샷 (Screenshots)
- (기존 UI와 외관상 동일하게 유지하되, 약관을 클릭했을 때 뜨는 상세 모달 하단에 **"새 창으로 보기"** 링크가 새롭게 추가되었습니다. 필요하시다면 해당 모달 화면 스크린샷을 이 부분에 첨부해 주세요.)
- 
<img width="1073" height="772" alt="image" src="https://github.com/user-attachments/assets/14be7e1a-6b30-42f8-bc62-7d141579abcc" />


## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`npm run build` 통과 완료)
- [x] 린트 에러가 없나요? (`npm run lint` 통과 및 불필요한 `useRouter` import 등 제거 완료)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?