### PR TITLE
refactor: 호버 

### DIFF
--- a/src/app/(admin)/admin/(app)/news/[id]/page.tsx
+++ b/src/app/(admin)/admin/(app)/news/[id]/page.tsx
@@ -148,7 +148,8 @@ export default function AdminNewsDetailPage() {
               body_2
               pl-[16px]
               gap-[8px]
-              hover:opacity-90
+              hover:bg-primary-3
+              transition-colors
             "
           >
             <Image

--- a/src/app/(admin)/admin/(app)/news/page.tsx
+++ b/src/app/(admin)/admin/(app)/news/page.tsx
@@ -118,7 +118,7 @@ export default function NewsPage() {
           rightAddon={
             <Link
               href="/admin/news/new"
-              className="flex-shrink-0 flex w-[187px] h-[48px] px-[16px] py-[12px] items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 text-White body_1_1 hover:opacity-90"
+              className="flex-shrink-0 flex w-[187px] h-[48px] px-[16px] py-[12px] items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 text-White body_1_1 hover:bg-primary-3 transition-colors"
             >
               소식 등록
             </Link>

--- a/src/app/(admin)/admin/(auth)/login/page.tsx
+++ b/src/app/(admin)/admin/(auth)/login/page.tsx
@@ -61,8 +61,8 @@ export default function AdminLoginPage() {
             rounded-[8px]
             bg-primary-1 text-white
             subhead_2
-            hover:opacity-80
-            transition-opacity
+            hover:bg-primary-3
+            transition-colors
             cursor-pointer
           "
         >

--- a/src/app/(main)/groups/GroupsPageClient.tsx
+++ b/src/app/(main)/groups/GroupsPageClient.tsx
@@ -184,7 +184,7 @@ export default function GroupsPageClient() {
             bgColorVar="--Primary_1"
             borderColorVar="--Primary_1"
             textColorVar="--White"
-            className="flex-1 body_1 hover:brightness-95 hover:-translate-y-[1px] cursor-pointer"
+            className="flex-1 body_1 hover:-translate-y-[1px] cursor-pointer"
             onClick={() => router.push("/groups/create")}
           />
         </div>
@@ -195,7 +195,7 @@ export default function GroupsPageClient() {
             bgColorVar="--Primary_1"
             borderColorVar="--Primary_1"
             textColorVar="--White"
-            className="flex-1 subhead_4_1 hover:brightness-95 hover:-translate-y-[1px] cursor-pointer"
+            className="flex-1 subhead_4_1 hover:-translate-y-[1px] cursor-pointer"
             onClick={() => router.push("/groups/create")}
           />
         </div>

--- a/src/app/(main)/groups/[id]/GroupDetailClient.tsx
+++ b/src/app/(main)/groups/[id]/GroupDetailClient.tsx
@@ -208,7 +208,7 @@ export default function GroupDetailClient() {
                   bgColorVar="--Primary_1"
                   borderColorVar="--Primary_1"
                   textColorVar="--White"
-                  className="w-[300px] h-[44px] body_1 hover:brightness-90 hover:-translate-y-[1px] cursor-pointer"
+                  className="w-[300px] h-[44px] body_1 hover:-translate-y-[1px] cursor-pointer"
                 />
                 <ButtonWithoutImg
                   text="Contact US"
@@ -219,7 +219,7 @@ export default function GroupDetailClient() {
                   bgColorVar="--Subbrown_4"
                   borderColorVar="--Subbrown_2"
                   textColorVar="--Primary_3"
-                  className="w-[300px] h-[44px] body_1 hover:brightness-95 hover:-translate-y-[1px] cursor-pointer"
+                  className="w-[300px] h-[44px] body_1 hover:-translate-y-[1px] cursor-pointer"
                 />
               </div>
             </div>
@@ -263,7 +263,7 @@ export default function GroupDetailClient() {
                 bgColorVar="--Primary_1"
                 borderColorVar="--Primary_1"
                 textColorVar="--White"
-                className="w-full d:w-[300px] h-[44px] body_1 hover:brightness-90 hover:-translate-y-[1px] cursor-pointer"
+                className="w-full d:w-[300px] h-[44px] body_1 hover:-translate-y-[1px] cursor-pointer"
               />
               <ButtonWithoutImg
                 text="Contact US"
@@ -274,7 +274,7 @@ export default function GroupDetailClient() {
                 bgColorVar="--Subbrown_4"
                 borderColorVar="--Subbrown_2"
                 textColorVar="--Primary_3"
-                className="w-full d:w-[300px] h-[44px] body_1 hover:brightness-95 hover:-translate-y-[1px] cursor-pointer"
+                className="w-full d:w-[300px] h-[44px] body_1 hover:-translate-y-[1px] cursor-pointer"
               />
             </div>
           </div>

--- a/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/edit/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/edit/page.tsx
@@ -446,7 +446,7 @@ export default function EditBookshelfPage() {
               <button
                 type="button"
                 onClick={handleCancel}
-                className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
+                className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3"
               >
                 취소
               </button>
@@ -454,9 +454,9 @@ export default function EditBookshelfPage() {
                 type="button"
                 onClick={handleSubmit}
                 disabled={!canSubmit || patchMutation.isPending}
-                className={`flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg body_1_2 transition-opacity ${!canSubmit || patchMutation.isPending
+                className={`flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg body_1_2 transition-colors ${!canSubmit || patchMutation.isPending
                     ? 'bg-Subbrown-4 text-Gray-4 cursor-not-allowed opacity-70'
-                    : 'bg-primary-2 text-White hover:opacity-90'
+                    : 'bg-primary-2 text-White hover:bg-primary-1'
                   }`}
               >
                 수정

--- a/src/app/(main)/groups/[id]/admin/bookcase/new/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/new/page.tsx
@@ -393,7 +393,7 @@ export default function NewBookshelfPage() {
               <button
                 type="button"
                 onClick={handleCancel}
-                className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
+                className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3"
               >
                 취소
               </button>
@@ -401,9 +401,9 @@ export default function NewBookshelfPage() {
                 type="button"
                 onClick={handleSubmit}
                 disabled={!canSubmit || createBookshelfMutation.isPending}
-                className={`flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg body_1_2 transition-opacity ${!canSubmit || createBookshelfMutation.isPending
+                className={`flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg body_1_2 transition-colors ${!canSubmit || createBookshelfMutation.isPending
                     ? 'bg-Subbrown-4 text-Gray-4 cursor-not-allowed opacity-70'
-                    : 'bg-primary-2 text-White hover:opacity-90'
+                    : 'bg-primary-2 text-White hover:bg-primary-1'
                   }`}
               >
                 등록

--- a/src/app/(main)/groups/[id]/admin/edit/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/edit/page.tsx
@@ -35,6 +35,13 @@ function cx(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
 
+const PRIMARY_FILLED_BUTTON_CLASS =
+  "bg-primary-1 text-White transition-colors hover:bg-primary-3 disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed";
+const SELECTABLE_BUTTON_ACTIVE_CLASS =
+  "bg-primary-1 border-primary-1 text-White transition-colors hover:bg-primary-3 hover:border-primary-3";
+const SELECTABLE_BUTTON_IDLE_CLASS =
+  "bg-Subbrown-4 border-Subbrown-3 text-primary-3 transition-colors hover:bg-Subbrown-3";
+
 const normalizeLinks = (links: SnsLink[]) =>
   links
     .map((link) => ({ label: link.label.trim(), url: link.url.trim() }))
@@ -440,12 +447,12 @@ export default function EditClubPage() {
                     w-[100px] h-[48px] t:w-[128px] t:h-[56px]
                     px-1 py-3 rounded-[8px]
                     body_1_2
-                    hover:opacity-90 active:opacity-80
+                    active:opacity-80
                     disabled:opacity-50 disabled:cursor-not-allowed
                   `,
                   DuplicationCheckisConfirmed
-                    ? "bg-primary-1 text-White border border-primary-1 disabled:opacity-100 disabled:cursor-default"
-                    : "border border-Subbrown-3 bg-Subbrown-4 text-primary-3"
+                    ? `${SELECTABLE_BUTTON_ACTIVE_CLASS} disabled:hover:bg-primary-1 disabled:hover:border-primary-1 disabled:opacity-100 disabled:cursor-default`
+                    : SELECTABLE_BUTTON_IDLE_CLASS
                 )}
               >
                 {nameCheck === "checking" ? "확인중" : "중복확인"}
@@ -539,10 +546,10 @@ export default function EditClubPage() {
                   }}
                   className={cx(
                     "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
-                    "hover:opacity-90 active:opacity-80",
+                    "active:opacity-80",
                     profileMode === "default"
-                      ? "bg-primary-1 border-primary-1 text-White"
-                      : "bg-Subbrown-4 border-Subbrown-3 text-primary-3"
+                      ? SELECTABLE_BUTTON_ACTIVE_CLASS
+                      : SELECTABLE_BUTTON_IDLE_CLASS
                   )}
                 >
                   기본 프로필 사용하기
@@ -556,10 +563,10 @@ export default function EditClubPage() {
                   }}
                   className={cx(
                     "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
-                    "hover:opacity-90 active:opacity-80",
+                    "active:opacity-80",
                     profileMode === "upload"
-                      ? "bg-primary-1 border-primary-1 text-White"
-                      : "bg-Subbrown-4 border-Subbrown-3 text-primary-3"
+                      ? SELECTABLE_BUTTON_ACTIVE_CLASS
+                      : SELECTABLE_BUTTON_IDLE_CLASS
                   )}
                 >
                   사진 업로드하기
@@ -761,8 +768,7 @@ export default function EditClubPage() {
               onClick={() => confirmNavigation(() => router.back())}
               className={cx(
                 "hidden t:flex justify-center items-center gap-[10px] w-[148px] h-[48px] px-4 py-3 rounded-[8px]",
-                "bg-primary-1 hover:bg-primary-3 text-White",
-                "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                PRIMARY_FILLED_BUTTON_CLASS
               )}
             >
               취소
@@ -775,8 +781,7 @@ export default function EditClubPage() {
               className={cx(
                 "flex justify-center items-center gap-[10px] h-[48px] px-4 py-3 rounded-[8px]",
                 "w-full t:w-[148px]",
-                "bg-primary-1 hover:bg-primary-3 text-White",
-                "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                PRIMARY_FILLED_BUTTON_CLASS
               )}
             >
               {updateClub.isPending ? "저장 중..." : "저장"}

--- a/src/app/(main)/groups/[id]/admin/notice/[noticeId]/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/notice/[noticeId]/page.tsx
@@ -788,14 +788,14 @@ export default function EditNoticePage() {
                 <button
                   type="button"
                   onClick={() => toast("임시저장은 미구현입니다.")}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3"
                 >
                   임시저장
                 </button>
                 <button
                   type="button"
                   onClick={handleSubmit}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 transition-colors"
                 >
                   수정
                 </button>

--- a/src/app/(main)/groups/[id]/admin/notice/new/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/notice/new/page.tsx
@@ -697,14 +697,14 @@ export default function NewNoticePage() {
                 <button
                   type="button"
                   onClick={() => toast("임시저장은 미구현입니다.")}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3"
                 >
                   임시저장
                 </button>
                 <button
                   type="button"
                   onClick={handleSubmit}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 transition-colors"
                 >
                   등록
                 </button>

--- a/src/app/(main)/groups/create/CreateGroupPageClient.tsx
+++ b/src/app/(main)/groups/create/CreateGroupPageClient.tsx
@@ -34,6 +34,13 @@ function cx(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
 
+const PRIMARY_FILLED_BUTTON_CLASS =
+  "bg-primary-1 text-White transition-colors hover:bg-primary-3 disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed";
+const SELECTABLE_BUTTON_ACTIVE_CLASS =
+  "bg-primary-1 border-primary-1 text-White transition-colors hover:bg-primary-3 hover:border-primary-3";
+const SELECTABLE_BUTTON_IDLE_CLASS =
+  "bg-Subbrown-4 border-Subbrown-3 text-primary-3 transition-colors hover:bg-Subbrown-3";
+
 const autoResize = (el: HTMLTextAreaElement) => {
   el.style.height = "0px";
   const H = el.scrollHeight + 5;
@@ -369,12 +376,12 @@ export default function CreateGroupPageClient() {
                       w-[100px] h-[48px] t:w-[128px] t:h-[56px]
                       px-1 py-3 rounded-[8px]
                       body_1_2
-                      hover:opacity-90 active:opacity-80
+                      active:opacity-80
                       disabled:opacity-50 disabled:cursor-not-allowed
                     `,
                     DuplicationCheckisConfirmed
-                      ? "bg-primary-1 text-White border border-primary-1 disabled:opacity-100 disabled:cursor-default"
-                      : "border border-Subbrown-3 bg-Subbrown-4 text-primary-3"
+                      ? `${SELECTABLE_BUTTON_ACTIVE_CLASS} disabled:hover:bg-primary-1 disabled:hover:border-primary-1 disabled:opacity-100 disabled:cursor-default`
+                      : SELECTABLE_BUTTON_IDLE_CLASS
                   )}
                 >
                   {nameCheck === "checking" ? "확인중" : "중복확인"}
@@ -434,8 +441,7 @@ export default function CreateGroupPageClient() {
                   className={cx(
                     "flex justify-center items-center gap-[10px] h-[48px] px-4 py-3 rounded-[8px]",
                     "w-full t:w-[148px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   다음
@@ -486,10 +492,10 @@ export default function CreateGroupPageClient() {
                     }}
                     className={cx(
                       "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
-                      "hover:opacity-90 active:opacity-80",
+                      "active:opacity-80",
                       profileMode === "default"
-                        ? "bg-primary-1 border-primary-1 text-White"
-                        : "bg-Subbrown-4 border-Subbrown-3 text-primary-3"
+                        ? SELECTABLE_BUTTON_ACTIVE_CLASS
+                        : SELECTABLE_BUTTON_IDLE_CLASS
                     )}
                   >
                     기본 프로필 사용하기
@@ -503,10 +509,10 @@ export default function CreateGroupPageClient() {
                     }}
                     className={cx(
                       "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
-                      "hover:opacity-90 active:opacity-80",
+                      "active:opacity-80",
                       profileMode === "upload"
-                        ? "bg-primary-1 border-primary-1 text-White"
-                        : "bg-Subbrown-4 border-Subbrown-3 text-primary-3"
+                        ? SELECTABLE_BUTTON_ACTIVE_CLASS
+                        : SELECTABLE_BUTTON_IDLE_CLASS
                     )}
                   >
                     사진 업로드하기
@@ -576,8 +582,7 @@ export default function CreateGroupPageClient() {
                   onClick={onPrev}
                   className={cx(
                     "hidden t:flex justify-center items-center gap-[10px] w-[148px] h-[48px] px-4 py-3 rounded-[8px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   이전
@@ -590,8 +595,7 @@ export default function CreateGroupPageClient() {
                   className={cx(
                     "flex justify-center items-center gap-[10px] h-[48px] px-4 py-3 rounded-[8px]",
                     "w-full t:w-[148px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   다음
@@ -656,8 +660,7 @@ export default function CreateGroupPageClient() {
                   onClick={onPrev}
                   className={cx(
                     "hidden t:flex justify-center items-center gap-[10px] w-[148px] h-[48px] px-4 py-3 rounded-[8px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   이전
@@ -670,8 +673,7 @@ export default function CreateGroupPageClient() {
                   className={cx(
                     "flex justify-center items-center gap-[10px] h-[48px] px-4 py-3 rounded-[8px]",
                     "w-full t:w-[148px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   다음
@@ -780,8 +782,7 @@ export default function CreateGroupPageClient() {
                   onClick={onPrev}
                   className={cx(
                     "hidden t:flex justify-center items-center gap-[10px] w-[148px] h-[48px] px-4 py-3 rounded-[8px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   이전
@@ -794,8 +795,7 @@ export default function CreateGroupPageClient() {
                   className={cx(
                     "flex justify-center items-center gap-[10px] h-[48px] px-4 py-3 rounded-[8px]",
                     "w-full t:w-[148px]",
-                    "bg-primary-1 hover:bg-primary-3 text-White",
-                    "disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed"
+                    PRIMARY_FILLED_BUTTON_CLASS
                   )}
                 >
                   {createClub.isPending ? "생성 중..." : "모임 생성"}

--- a/src/app/(main)/setting/password/PasswordChangePageClient.tsx
+++ b/src/app/(main)/setting/password/PasswordChangePageClient.tsx
@@ -53,7 +53,7 @@ export default function PasswordChangePageClient() {
   };
 
   const buttonStyle =
-    "flex h-[48px] items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] py-[12px] w-[120px] md:w-[200px] disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed";
+    "flex h-[48px] items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] py-[12px] w-[120px] md:w-[200px] transition-colors hover:bg-primary-3 disabled:hover:bg-primary-1 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed";
   const buttonTextStyle = "body_1_1 text-White";
   const inputContainerClass =
     "flex h-[52px] w-full items-center gap-[10px] rounded-[8px] border border-Subbrown-4 bg-White px-[16px] py-[12px]";

--- a/src/app/(main)/setting/profile/ProfileEditPageClient.tsx
+++ b/src/app/(main)/setting/profile/ProfileEditPageClient.tsx
@@ -287,7 +287,7 @@ export default function ProfileEditPageClient() {
         <button
           onClick={handleSave}
           disabled={isUpdating}
-          className="flex h-[48px] w-[200px] items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] py-[12px] disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+          className="flex h-[48px] w-[200px] items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] py-[12px] transition-colors hover:bg-primary-3 disabled:hover:bg-primary-1 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
         >
           <span className="text-[14px] font-semibold leading-[145%] tracking-[-0.014px] text-White">
             <span className="md:hidden">{isUpdating ? "변경 중..." : "변경하기"}</span>

--- a/src/app/(main)/setting/support/SupportPageClient.tsx
+++ b/src/app/(main)/setting/support/SupportPageClient.tsx
@@ -40,7 +40,7 @@ export default function SupportPageClient() {
                 <div className="flex flex-col w-[320px] md:w-[400px] gap-4">
                     <button
                         onClick={handleOpenForm}
-                        className="w-full h-[56px] bg-primary-3 text-white rounded-[12px] subhead_4_1 hover:bg-primary-2 transition-colors shadow-md active:scale-[0.98] cursor-pointer"
+                        className="w-full h-[56px] bg-primary-3 text-white rounded-[12px] subhead_4_1 hover:brightness-90 transition-all shadow-md active:scale-[0.98] cursor-pointer"
                     >
                         문의하기 폼 열기
                     </button>

--- a/src/app/(main)/stories/[id]/edit/StoryEditPageClient.tsx
+++ b/src/app/(main)/stories/[id]/edit/StoryEditPageClient.tsx
@@ -195,7 +195,7 @@ export default function StoryEditPageClient() {
                   type="button"
                   onClick={() => handleSubmit("DRAFT")}
                   disabled={isPending}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-primary-1 disabled:opacity-50"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3 disabled:hover:bg-background disabled:opacity-50"
                 >
                   {isPending ? "임시저장 중..." : "임시저장"}
                 </button>
@@ -203,7 +203,7 @@ export default function StoryEditPageClient() {
                   type="button"
                   onClick={() => handleSubmit("PUBLISHED")}
                   disabled={isPending}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 transition-colors disabled:hover:bg-primary-2 disabled:opacity-50"
                 >
                   {isPending ? "발행 중..." : "발행"}
                 </button>
@@ -221,7 +221,7 @@ export default function StoryEditPageClient() {
                   type="button"
                   onClick={() => handleSubmit()}
                   disabled={isPending}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
+                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 transition-colors disabled:hover:bg-primary-2 disabled:opacity-50"
                 >
                   {isPending ? "저장 중..." : "저장"}
                 </button>

--- a/src/app/(main)/stories/new/StoryNewPageClient.tsx
+++ b/src/app/(main)/stories/new/StoryNewPageClient.tsx
@@ -175,7 +175,7 @@ function StoryNewContent() {
               type="button"
               onClick={() => handleSubmit("DRAFT")}
               disabled={createStoryMutation.isPending}
-              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-primary-1 disabled:opacity-50"
+              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3 disabled:hover:bg-background disabled:opacity-50"
             >
               {createStoryMutation.isPending ? "임시저장 중..." : "임시저장"}
             </button>
@@ -183,7 +183,7 @@ function StoryNewContent() {
               type="button"
               onClick={() => handleSubmit("PUBLISHED")}
               disabled={createStoryMutation.isPending}
-              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:opacity-90 transition-opacity disabled:opacity-50"
+              className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 transition-colors disabled:hover:bg-primary-2 disabled:opacity-50"
             >
               {createStoryMutation.isPending ? "등록 중..." : "등록"}
             </button>

--- a/src/components/base-ui/Admin/ConfirmModal.tsx
+++ b/src/components/base-ui/Admin/ConfirmModal.tsx
@@ -60,7 +60,7 @@ export default function ConfirmModal({ isOpen, message, onConfirm, onCancel }: C
                                 onConfirm();
                                 onCancel();
                             }}
-                            className="flex-1 h-[48px] rounded-lg bg-primary-3 text-White body_1_2 hover:bg-primary-3/90 transition-colors"
+                            className="flex-1 h-[48px] rounded-lg bg-primary-3 text-White body_1_2 hover:brightness-90 transition-all"
                         >
                             확인
                         </button>

--- a/src/components/base-ui/Admin/stories/bookstory_detail.tsx
+++ b/src/components/base-ui/Admin/stories/bookstory_detail.tsx
@@ -170,8 +170,8 @@ export default function BookstoryDetail({
             onClick={onSubscribeClick}
             className={`flex px-4 py-1.5 justify-center items-center rounded-lg text-White text-[12px] font-medium shrink-0 transition-colors ${
               isFollowing
-                ? "bg-Subbrown-4 text-primary-3"
-                : "bg-primary-2 text-White"
+                ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+                : "bg-primary-2 text-White hover:bg-primary-1"
             }`}
           >
             {subscribeText}
@@ -353,8 +353,8 @@ export default function BookstoryDetail({
               onClick={onSubscribeClick}
               className={`flex px-[17px] py-[8px] justify-center items-center rounded-lg body_2_1 shrink-0 whitespace-nowrap cursor-pointer transition-colors ${
                 isFollowing
-                  ? "bg-Subbrown-4 text-primary-3"
-                  : "bg-primary-2 text-White"
+                  ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+                  : "bg-primary-2 text-White hover:bg-primary-1"
               }`}
             >
               {subscribeText}

--- a/src/components/base-ui/BookStory/Common/bookstory_card.tsx
+++ b/src/components/base-ui/BookStory/Common/bookstory_card.tsx
@@ -103,9 +103,9 @@ export default function BookStoryCard({
               e.stopPropagation();
               onSubscribeClick?.();
             }}
-            className={`h-8 rounded-lg px-[17px] body_2_1 whitespace-nowrap transition-all hover:brightness-90 active:scale-95 ${isFollowing
-              ? "bg-Subbrown-4 text-primary-3"
-              : "bg-primary-2 text-White"
+            className={`h-8 rounded-lg px-[17px] body_2_1 whitespace-nowrap transition-all active:scale-95 ${isFollowing
+              ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+              : "bg-primary-2 text-White hover:bg-primary-1"
               }`}
           >
             {subscribeText}
@@ -169,7 +169,7 @@ export default function BookStoryCard({
               e.stopPropagation();
               onContinueClick?.(e);
             }}
-            className="w-full h-10 rounded-lg bg-primary-2 text-White body_1_2 hover:brightness-110 active:scale-95 transition-all flex items-center justify-center gap-2"
+            className="w-full h-10 rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 active:scale-95 transition-all flex items-center justify-center gap-2"
           >
             <div className="relative w-4 h-4">
               <Image src="/pencil_icon.svg" alt="edit" fill className="object-contain brightness-0 invert" />

--- a/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
+++ b/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
@@ -203,8 +203,8 @@ export default function BookstoryDetail({
             type="button"
             onClick={onSubscribeClick}
             className={`flex px-4 py-1.5 justify-center items-center rounded-lg text-White text-[12px] font-medium shrink-0 transition-colors ${isFollowing
-              ? "bg-Subbrown-4 text-primary-3"
-              : "bg-primary-2 text-White"
+              ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+              : "bg-primary-2 text-White hover:bg-primary-1"
               }`}
           >
             {subscribeText}
@@ -343,8 +343,8 @@ export default function BookstoryDetail({
               type="button"
               onClick={onSubscribeClick}
               className={`flex px-[17px] py-[8px] justify-center items-center rounded-lg body_2_1 shrink-0 whitespace-nowrap cursor-pointer transition-colors ${isFollowing
-                ? "bg-Subbrown-4 text-primary-3"
-                : "bg-primary-2 text-White"
+                ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+                : "bg-primary-2 text-White hover:bg-primary-1"
                 }`}
             >
               {subscribeText}

--- a/src/components/base-ui/Bookcase/bookid/BookshelfDeleteConfirmModal.tsx
+++ b/src/components/base-ui/Bookcase/bookid/BookshelfDeleteConfirmModal.tsx
@@ -96,7 +96,7 @@ export default function BookshelfDeleteConfirmModal({
             type="button"
             onClick={onConfirm}
             disabled={isPending}
-            className="h-[44px] rounded-[8px] bg-primary-2 text-White body_1_2 hover:brightness-95 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+            className="h-[44px] rounded-[8px] bg-primary-2 text-White body_1_2 transition-colors hover:bg-primary-1 disabled:hover:bg-primary-2 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
           >
             {isPending ? "삭제중..." : confirmText}
           </button>
@@ -105,7 +105,7 @@ export default function BookshelfDeleteConfirmModal({
             type="button"
             onClick={onClose}
             disabled={isPending}
-            className="h-[44px] rounded-[8px] border border-Subbrown-4 bg-White text-Gray-7 body_1_2 hover:brightness-95 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+            className="h-[44px] rounded-[8px] border border-Subbrown-4 bg-White text-Gray-7 body_1_2 transition-colors hover:bg-Subbrown-3 disabled:hover:bg-White disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
           >
             {cancelText}
           </button>

--- a/src/components/base-ui/Comment/comment_edit_form.tsx
+++ b/src/components/base-ui/Comment/comment_edit_form.tsx
@@ -42,7 +42,7 @@ export default function CommentEditForm({
         <button
           type="button"
           onClick={handleSave}
-          className="px-4 py-2 rounded-lg bg-primary-3 text-White subhead_4_1 cursor-pointer"
+          className="px-4 py-2 rounded-lg bg-primary-3 text-White subhead_4_1 cursor-pointer transition-all hover:brightness-90"
         >
           저장
         </button>

--- a/src/components/base-ui/Float.tsx
+++ b/src/components/base-ui/Float.tsx
@@ -40,7 +40,7 @@ export default function FloatingFab({
 
         "cursor-pointer",
         "active:-translate-y-[6px] active:brightness-95",
-        "hover:brightness-90",
+        "transition-colors hover:bg-primary-1",
         className,
       ].join(" ")}
     >

--- a/src/components/base-ui/Join/steps/ProfileImage/ProfileImageUploader.tsx
+++ b/src/components/base-ui/Join/steps/ProfileImage/ProfileImageUploader.tsx
@@ -40,7 +40,7 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
         />
         <button
           onClick={handleEditClick}
-          className="absolute bottom-0 right-0 p-[10px] rounded-[79px] bg-primary-3 flex justify-center items-center cursor-pointer"
+          className="absolute bottom-0 right-0 p-[10px] rounded-[79px] bg-primary-3 flex justify-center items-center cursor-pointer transition-all hover:brightness-90"
         >
           <svg
             width="24"
@@ -68,7 +68,7 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
       </div>
       <button
         onClick={onReset}
-        className="px-[20px] py-[10px] rounded-[8px] bg-primary-3 text-White text-[18px] font-medium leading-[135%] tracking-[-0.018px] cursor-pointer"
+        className="px-[20px] py-[10px] rounded-[8px] bg-primary-3 text-White text-[18px] font-medium leading-[135%] tracking-[-0.018px] cursor-pointer transition-all hover:brightness-90"
       >
         기본 프로필 이미지
       </button>

--- a/src/components/base-ui/Landing/LandingChatSection.tsx
+++ b/src/components/base-ui/Landing/LandingChatSection.tsx
@@ -291,7 +291,7 @@ export default function LandingChatSection() {
           </div>
           <button
             onClick={handleJoin}
-            className="subhead_3_2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition hover:brightness-110 hover:shadow-lg active:scale-95"
+            className="subhead_3_2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition hover:bg-primary-3 hover:shadow-lg active:scale-95"
           >
             지금 가입하기
           </button>

--- a/src/components/base-ui/Landing/LandingHero.tsx
+++ b/src/components/base-ui/Landing/LandingHero.tsx
@@ -53,7 +53,7 @@ export default function LandingHero() {
 
         <button
           onClick={handleJoin}
-          className="subhead_3_2 mt-2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition hover:brightness-110 hover:shadow-lg active:scale-95"
+          className="subhead_3_2 mt-2 cursor-pointer rounded-full bg-primary-1 px-8 py-3.5 text-white transition hover:bg-primary-3 hover:shadow-lg active:scale-95"
         >
           지금 가입하기
         </button>

--- a/src/components/base-ui/Landing/LandingNav.tsx
+++ b/src/components/base-ui/Landing/LandingNav.tsx
@@ -50,7 +50,7 @@ export default function LandingNav() {
             className={`body_2_1 cursor-pointer rounded-full px-4 py-1.5 transition-all active:scale-95 t:body_1_1 t:px-5 t:py-2 ${
               scrolled
                 ? "bg-white text-primary-1 hover:bg-white/90 hover:shadow-md"
-                : "bg-primary-1 text-white hover:brightness-110 hover:shadow-md"
+                : "bg-primary-1 text-white hover:bg-primary-3 hover:shadow-md"
             }`}
           >
             로그인/회원가입

--- a/src/components/base-ui/Login/components/LoginForm.tsx
+++ b/src/components/base-ui/Login/components/LoginForm.tsx
@@ -102,7 +102,7 @@ export default function LoginForm({
       {/* 로그인 버튼 */}
       <button
         type="button"
-        className="flex items-center justify-center w-full h-[32px] t:h-[48px] rounded-lg bg-primary-1 text-White font-semibold text-sm border-none cursor-pointer transition-all active:brightness-90 disabled:bg-Gray-3 disabled:cursor-not-allowed shrink-0"
+        className="flex items-center justify-center w-full h-[32px] t:h-[48px] rounded-lg bg-primary-1 text-White font-semibold text-sm border-none cursor-pointer transition-all hover:bg-primary-3 active:brightness-90 disabled:bg-Gray-3 disabled:hover:bg-Gray-3 disabled:cursor-not-allowed shrink-0"
         onClick={onLogin}
         disabled={isLoading}
       >
@@ -111,6 +111,5 @@ export default function LoginForm({
     </div>
   );
 }
-
 
 

--- a/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
+++ b/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
@@ -29,13 +29,13 @@ function ActionButton({
 
   const variants = {
     primary:
-      "bg-primary-1 text-White font-semibold md:font-medium w-[220px] h-[32px] md:w-[486px] md:h-[48px] lg:w-[532px]",
+      "bg-primary-1 text-White font-semibold md:font-medium hover:bg-primary-3 w-[220px] h-[32px] md:w-[486px] md:h-[48px] lg:w-[532px]",
 
     following:
-      "bg-[var(--Subbrown_4)] text-primary-3 font-semibold md:font-medium w-[220px] h-[32px] md:w-[486px] md:h-[48px] lg:w-[532px]",
+      "bg-[var(--Subbrown_4)] text-primary-3 font-semibold md:font-medium hover:bg-Subbrown-3 w-[220px] h-[32px] md:w-[486px] md:h-[48px] lg:w-[532px]",
 
     secondary:
-      "bg-White border border-Subbrown-3 text-Gray-4 font-medium hover:bg-gray-50 w-[100px] h-[32px] md:w-[178px] md:h-[48px]",
+      "bg-White border border-Subbrown-3 text-Gray-4 font-medium hover:bg-Subbrown-3 w-[100px] h-[32px] md:w-[178px] md:h-[48px]",
   };
 
   const textStyles = "body_1_2 md:subhead_4_1";

--- a/src/components/base-ui/Search/search_bookresult.tsx
+++ b/src/components/base-ui/Search/search_bookresult.tsx
@@ -115,7 +115,7 @@ export default function SearchBookResult({
                 flex w-12 h-12 t:w-15 t:h-15 px-[10px] py-[4.167px]
                 flex-col justify-center items-center gap-[8.333px] shrink-0
                 rounded-full bg-primary-2
-                cursor-pointer active:-translate-y-[6px] active:brightness-95 hover:brightness-90
+                cursor-pointer transition-colors hover:bg-primary-1 active:-translate-y-[6px] active:brightness-95
               "
         >
           <Image src="/pencil_icon.svg" alt="" width={20} height={20} />

--- a/src/components/base-ui/Settings/EditProfile/ProfileImageSection.tsx
+++ b/src/components/base-ui/Settings/EditProfile/ProfileImageSection.tsx
@@ -81,7 +81,7 @@ export default function ProfileImageSection({
       <div className="flex items-center gap-[12px] self-stretch">
         <button
           onClick={handleUploadClick}
-          className="flex flex-1 items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] cursor-pointer
+          className="flex flex-1 items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] cursor-pointer transition-colors hover:bg-primary-3
           h-[36px] md:h-[48px]"
         >
           <span
@@ -94,7 +94,7 @@ export default function ProfileImageSection({
         </button>
         <button
           onClick={onReset}
-          className="flex flex-1 items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] cursor-pointer
+          className="flex flex-1 items-center justify-center gap-[10px] rounded-[8px] bg-primary-1 px-[16px] cursor-pointer transition-colors hover:bg-primary-3
           h-[36px] md:h-[48px]"
         >
           <span

--- a/src/components/base-ui/button_without_img.tsx
+++ b/src/components/base-ui/button_without_img.tsx
@@ -31,6 +31,21 @@ const toCssColor = (v?: string) => {
   return s;
 };
 
+const normalizeCssColor = (v?: string) => v?.trim().replace(/^var\((--[^)]+)\)$/, '$1');
+
+const DEFAULT_HOVER_COLOR_BY_TOKEN: Record<string, string> = {
+  '--Primary_1': '--Primary_3',
+  '--Primary_2': '--Primary_1',
+  '--Subbrown_4': '--Subbrown_3',
+  '--White': '--Subbrown_3',
+  '--background': '--Subbrown_3',
+};
+
+const getDefaultHoverColor = (v?: string) => {
+  const token = normalizeCssColor(v);
+  return token ? DEFAULT_HOVER_COLOR_BY_TOKEN[token] : undefined;
+};
+
 export default function ButtonWithoutImg({
   text,
   onClick,
@@ -52,9 +67,16 @@ export default function ButtonWithoutImg({
 }: ButtonWithoutImgProps) {
   const [isHover, setIsHover] = useState(false);
 
-  const bg = toCssColor(isHover && hoverBgColorVar ? hoverBgColorVar : bgColorVar);
-  const border = toCssColor(isHover && hoverBorderColorVar ? hoverBorderColorVar : borderColorVar);
-  const textColor = toCssColor(isHover && hoverTextColorVar ? hoverTextColorVar : textColorVar);
+  const shouldUseHover = isHover && !disabled;
+  const bg = toCssColor(
+    shouldUseHover ? hoverBgColorVar ?? getDefaultHoverColor(bgColorVar) ?? bgColorVar : bgColorVar
+  );
+  const border = toCssColor(
+    shouldUseHover
+      ? hoverBorderColorVar ?? getDefaultHoverColor(borderColorVar) ?? borderColorVar
+      : borderColorVar
+  );
+  const textColor = toCssColor(shouldUseHover ? hoverTextColorVar ?? textColorVar : textColorVar);
 
   return (
     <button
@@ -73,6 +95,7 @@ export default function ButtonWithoutImg({
       className={[
         'flex px-[16px] py-[12px] justify-center items-center gap-[10px]',
         'rounded-[8px] border',
+        'transition-colors',
         disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
         className,
       ].join(' ')}

--- a/src/components/base-ui/home/Club/HomeClubSection.tsx
+++ b/src/components/base-ui/home/Club/HomeClubSection.tsx
@@ -62,8 +62,8 @@ export default function HomeClubSection({ groups, isLoading }: HomeClubSectionPr
       <button
         type="button"
         onClick={handleCreateGroup}
-        className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-[#6B5448] text-white
-                  text-[13px] flex items-center justify-center gap-2 cursor-pointer"
+        className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-primary-3 text-white
+                  text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-90"
       >
         <Image
           src="/icon_plus.svg"

--- a/src/components/base-ui/home/Club/home_bookclub.tsx
+++ b/src/components/base-ui/home/Club/home_bookclub.tsx
@@ -122,7 +122,7 @@ export default function HomeBookclub({ groups }: Props) {
               <button
                 type="button"
                 onClick={handleCreateGroup}
-                className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-[#6B5448] text-white text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-90 hover:-translate-y-[1px]"
+                className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-primary-3 text-white text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-90 hover:-translate-y-[1px]"
               >
                 <Image
                   src="/icon_plus.svg"

--- a/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
@@ -57,8 +57,8 @@ export default function ListSubscribeElement({
           type="button"
           onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
           className={`hidden t:flex px-[10px] t:px-[17px] py-[6px] t:py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[11px] t:text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors ${isFollowing
-            ? "bg-Subbrown-4 text-primary-3"
-            : "bg-primary-2 text-white"
+            ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+            : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
         >
           {buttonText}
@@ -68,8 +68,8 @@ export default function ListSubscribeElement({
           type="button"
           onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
           className={`flex t:hidden w-full px-[17px] py-[6px] justify-center items-center rounded-[10px] text-[11px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap transition-colors ${isFollowing
-            ? "bg-Subbrown-4 text-primary-3"
-            : "bg-primary-2 text-white"
+            ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+            : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
         >
           {buttonText}

--- a/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
@@ -57,8 +57,8 @@ function ListSubscribeElementLarge({
           type="button"
           onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
           className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors ${isFollowing
-            ? "bg-Subbrown-4 text-primary-3"
-            : "bg-primary-2 text-white"
+            ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+            : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
         >
           {buttonText}

--- a/src/components/base-ui/home/Subscription/list_subscribe_element.tsx
+++ b/src/components/base-ui/home/Subscription/list_subscribe_element.tsx
@@ -50,8 +50,8 @@ export default function ListSubscribeElement({
           type="button"
           onClick={onSubscribeClick}
           className={`hidden t:flex px-[10px] t:px-[17px] py-[6px] t:py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[11px] t:text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors cursor-pointer ${isFollowing
-            ? "bg-Subbrown-4 text-primary-3"
-            : "bg-primary-2 text-white"
+            ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+            : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
         >
           {buttonText}
@@ -61,8 +61,8 @@ export default function ListSubscribeElement({
           type="button"
           onClick={onSubscribeClick}
           className={`flex t:hidden w-full px-[17px] py-[6px] justify-center items-center rounded-[10px] text-[11px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap transition-colors cursor-pointer ${isFollowing
-            ? "bg-Subbrown-4 text-primary-3"
-            : "bg-primary-2 text-white"
+            ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+            : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
         >
           {buttonText}

--- a/src/components/base-ui/home/Subscription/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Subscription/list_subscribe_large.tsx
@@ -50,8 +50,8 @@ function ListSubscribeElementLarge({
           type="button"
           onClick={onSubscribeClick}
           className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors cursor-pointer ${isFollowing
-            ? "bg-Subbrown-4 text-primary-3"
-            : "bg-primary-2 text-white"
+            ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
+            : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
         >
           {buttonText}

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -61,7 +61,7 @@ export default function ConfirmModal({ isOpen, message, onConfirm, onCancel, clo
                                 onConfirm();
                                 if (closeOnConfirm) onCancel();
                             }}
-                            className="flex-1 h-[48px] rounded-lg bg-primary-3 text-White body_1_2 hover:bg-primary-3/90 transition-colors cursor-pointer"
+                            className="flex-1 h-[48px] rounded-lg bg-primary-3 text-White body_1_2 hover:brightness-90 transition-all cursor-pointer"
                         >
                             확인
                         </button>

--- a/src/components/common/UnsavedChangesConfirmModal.tsx
+++ b/src/components/common/UnsavedChangesConfirmModal.tsx
@@ -72,14 +72,14 @@ export default function UnsavedChangesConfirmModal({
           <button
             type="button"
             onClick={onLeave}
-            className="h-[44px] rounded-[8px] border border-Subbrown-4 bg-White text-Gray-7 body_1_2 hover:brightness-95 cursor-pointer"
+            className="h-[44px] rounded-[8px] border border-Subbrown-4 bg-White text-Gray-7 body_1_2 transition-colors hover:bg-Subbrown-3 cursor-pointer"
           >
             {leaveText}
           </button>
           <button
             type="button"
             onClick={onStay}
-            className="h-[44px] rounded-[8px] bg-primary-2 text-White body_1_2 hover:brightness-95 cursor-pointer"
+            className="h-[44px] rounded-[8px] bg-primary-2 text-White body_1_2 transition-colors hover:bg-primary-1 cursor-pointer"
           >
             {stayText}
           </button>

--- a/src/components/common/modals/report-block/ActionSelectionModal.tsx
+++ b/src/components/common/modals/report-block/ActionSelectionModal.tsx
@@ -85,21 +85,21 @@ export default function ActionSelectionModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="w-full md:flex-1 h-[48px] bg-White border border-Subbrown-3 text-Gray-5 rounded-[8px] subhead_4_1 transition-colors hover:bg-gray-50 cursor-pointer"
+                className="w-full md:flex-1 h-[48px] bg-White border border-Subbrown-3 text-Gray-5 rounded-[8px] subhead_4_1 transition-colors hover:bg-Subbrown-3 cursor-pointer"
               >
                 취소
               </button>
               <button
                 type="button"
                 onClick={onSelectReport}
-                className="w-full md:flex-1 h-[48px] bg-primary-1 text-White rounded-[8px] subhead_4_1 transition-colors hover:bg-primary-1/90 cursor-pointer"
+                className="w-full md:flex-1 h-[48px] bg-primary-1 text-White rounded-[8px] subhead_4_1 transition-colors hover:bg-primary-3 cursor-pointer"
               >
                 신고하기
               </button>
               <button
                 type="button"
                 onClick={onSelectBlock}
-                className="w-full md:flex-1 h-[48px] bg-primary-1 border border-Subbrown-3 text-White rounded-[8px] subhead_4_1 transition-colors hover:bg-primary-1/90 cursor-pointer"
+                className="w-full md:flex-1 h-[48px] bg-primary-1 border border-primary-1 text-White rounded-[8px] subhead_4_1 transition-colors hover:bg-primary-3 hover:border-primary-3 cursor-pointer"
               >
                 차단하기
               </button>

--- a/src/components/common/modals/report-block/BlockConfirmModal.tsx
+++ b/src/components/common/modals/report-block/BlockConfirmModal.tsx
@@ -76,14 +76,14 @@ export default function BlockConfirmModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="flex-1 h-[48px] bg-White border border-Subbrown-3 text-Gray-5 rounded-[8px] subhead_4_1 transition-colors hover:bg-gray-50 cursor-pointer"
+                className="flex-1 h-[48px] bg-White border border-Subbrown-3 text-Gray-5 rounded-[8px] subhead_4_1 transition-colors hover:bg-Subbrown-3 cursor-pointer"
               >
                 취소
               </button>
               <button
                 type="button"
                 onClick={onConfirmBlock}
-                className="flex-1 h-[48px] bg-primary-1 text-White rounded-[8px] subhead_4_1 transition-colors hover:bg-primary-1/90 cursor-pointer"
+                className="flex-1 h-[48px] bg-primary-1 text-White rounded-[8px] subhead_4_1 transition-colors hover:bg-primary-3 cursor-pointer"
               >
                 차단
               </button>

--- a/src/components/common/modals/report-block/ReportModal.tsx
+++ b/src/components/common/modals/report-block/ReportModal.tsx
@@ -141,7 +141,7 @@ export default function ReportModal({ isOpen, onClose, onSubmit, defaultReason =
                                 }
                             }}
                             className={`flex h-12 t:h-[56px] p-4 t:p-[20px] justify-center items-center gap-[10px] self-stretch rounded-[8px] transition-colors ${isSubmitEnabled
-                                ? "bg-primary-1 text-White hover:bg-primary-1/90 cursor-pointer"
+                                ? "bg-primary-1 text-White hover:bg-primary-3 cursor-pointer"
                                 : "bg-Gray-1 text-Gray-3 cursor-not-allowed"
                                 }`}
                         >


### PR DESCRIPTION
## 📌 개요 (Summary)
- primary 계열 버튼 hover 색상이 밝아지거나 opacity/brightness로 제각각 적용되던 문제를 수정했습니다.
- 버튼 hover 색상을 토큰 기준으로 통일했습니다.
- 관련 이슈: #465

## 🛠 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명:)

### 상세 변경 내용
- `primary-1` 버튼 hover: `primary-3`로 통일
- `primary-2` 버튼 hover: `primary-1`로 통일
- `primary-3` 버튼 hover: 더 어두운 토큰이 없어 `brightness-90` 예외 적용
- 밝은/outlined 버튼 hover: `Subbrown-3` 계열로 통일
- `ButtonWithoutImg`에 기본 hover 색상 매핑 추가
- 모임, 스토리, 공지, 책장, 설정, 프로필, 신고/차단 모달, 랜딩 CTA 버튼 hover 정리

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

### 테스트 메모
- `git diff --check` 통과
- primary filled 버튼의 `hover:opacity`, `hover:brightness`, `hover:bg-primary-*/90`, `hover:brightness-110` 잔여 패턴 없음
- `ButtonWithoutImg` 단독 eslint 통과
- `pnpm lint`는 기존 repo-wide lint 오류로 실패
- `pnpm build`는 Next build 최적화 단계에서 장시간 무응답으로 중단