### PR TITLE
Refactor/467 mypage social

### DIFF
--- a/src/app/(main)/setting/SettingsPageClient.tsx
+++ b/src/app/(main)/setting/SettingsPageClient.tsx
@@ -6,9 +6,20 @@ import Image from "next/image";
 import Link from "next/link";
 import { SETTINGS_MENU } from "@/constants/setting/setting";
 import { EXTERNAL_LINKS } from "@/constants/links";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export default function SettingsPageClient() {
   const router = useRouter();
+  const { user } = useAuthStore();
+
+  const filteredMenu = SETTINGS_MENU.map((group) => ({
+    ...group,
+    items: group.items.filter((item) => {
+      if (item.href === "/setting/email" && user?.social) return false;
+      return true;
+    }),
+  }));
+
 
   // 데스크탑(xl, 1280px 이상)에서는 설정 진입 시 '프로필 편집'으로 리다이렉트
   useEffect(() => {
@@ -28,7 +39,7 @@ export default function SettingsPageClient() {
     <div className="flex w-full flex-col items-center pt-[10px] xl:hidden">
       {/* 메뉴 리스트 컨테이너 (width: 339px) */}
       <div className="flex w-[339px] flex-col items-start gap-[8px]">
-        {SETTINGS_MENU.map((group) => (
+        {filteredMenu.map((group) => (
           <div
             key={group.category}
             className="flex flex-col items-start gap-[8px] self-stretch"

--- a/src/app/(main)/setting/email/EmailChangePageClient.tsx
+++ b/src/app/(main)/setting/email/EmailChangePageClient.tsx
@@ -2,17 +2,26 @@
 
 import SettingsInputGroup from "@/components/base-ui/Settings/SettingsInputGroup";
 import SettingsDetailLayout from "@/components/base-ui/Settings/SettingsDetailLayout";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useVerifyEmailMutation } from "@/hooks/mutations/useAuthMutations";
 import { useUpdateEmailMutation } from "@/hooks/mutations/useMemberMutations";
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export default function EmailChangePageClient() {
   const [currentEmail, setCurrentEmail] = useState("");
   const [newEmail, setNewEmail] = useState("");
   const [verificationCode, setVerificationCode] = useState("");
   const router = useRouter();
+  const { user } = useAuthStore();
+
+  useEffect(() => {
+    if (user?.social) {
+      toast.error("소셜 로그인 회원은 이메일을 변경할 수 없습니다.");
+      router.replace("/setting");
+    }
+  }, [user, router]);
 
   const { mutate: verifyEmail, isPending: isVerifying } = useVerifyEmailMutation();
   const { mutate: updateEmail, isPending: isUpdating } = useUpdateEmailMutation();

--- a/src/app/(main)/setting/email/EmailChangePageClient.tsx
+++ b/src/app/(main)/setting/email/EmailChangePageClient.tsx
@@ -2,7 +2,7 @@
 
 import SettingsInputGroup from "@/components/base-ui/Settings/SettingsInputGroup";
 import SettingsDetailLayout from "@/components/base-ui/Settings/SettingsDetailLayout";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useVerifyEmailMutation } from "@/hooks/mutations/useAuthMutations";
 import { useUpdateEmailMutation } from "@/hooks/mutations/useMemberMutations";
 import { toast } from "react-hot-toast";
@@ -15,13 +15,16 @@ export default function EmailChangePageClient() {
   const [verificationCode, setVerificationCode] = useState("");
   const router = useRouter();
   const { user } = useAuthStore();
+  const toastShownRef = useRef(false);
 
   useEffect(() => {
-    if (user?.social) {
+    if (user?.social && !toastShownRef.current) {
+      toastShownRef.current = true;
       toast.error("소셜 로그인 회원은 이메일을 변경할 수 없습니다.");
       router.replace("/setting");
     }
   }, [user, router]);
+
 
   const { mutate: verifyEmail, isPending: isVerifying } = useVerifyEmailMutation();
   const { mutate: updateEmail, isPending: isUpdating } = useUpdateEmailMutation();

--- a/src/components/base-ui/Settings/SettingsSidebar.tsx
+++ b/src/components/base-ui/Settings/SettingsSidebar.tsx
@@ -5,10 +5,20 @@ import { usePathname, useRouter } from "next/navigation";
 import { SETTINGS_MENU } from "@/constants/setting/setting";
 import { EXTERNAL_LINKS } from "@/constants/links";
 import SettingsMenuItem from "./Items/SettingsMenuItem";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export default function SettingsSidebar() {
   const pathname = usePathname();
   const router = useRouter();
+  const { user } = useAuthStore();
+
+  const filteredMenu = SETTINGS_MENU.map((group) => ({
+    ...group,
+    items: group.items.filter((item) => {
+      if (item.href === "/setting/email" && user?.social) return false;
+      return true;
+    }),
+  }));
 
   return (
     <aside className="hidden md:flex md:w-[180px] xl:w-[236px] shrink-0 flex-col items-start bg-transparent transition-all duration-300">
@@ -19,7 +29,7 @@ export default function SettingsSidebar() {
 
       {/* 메뉴 그룹 */}
       <nav className="flex flex-col items-start gap-[8px] self-stretch">
-        {SETTINGS_MENU.map((group) => (
+        {filteredMenu.map((group) => (
           <div
             key={group.category}
             className="flex flex-col items-start self-stretch"

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -7,6 +7,7 @@ export interface User {
   profileImageUrl?: string;
   categories?: string[];
   profileCompleted?: boolean;
+  social?: boolean;
 }
 
 export interface LoginForm {

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -35,6 +35,7 @@ export interface ProfileResponse {
     description: string;
     profileImageUrl: string;
     categories: string[];
+    social: boolean;
 }
 
 export interface OtherProfileResponse {


### PR DESCRIPTION
## 📌 개요 (Summary)
- **소셜 로그인 사용자의 이메일 변경 기능 접근 차단 및 UI 처리 완료**
- 기존 이메일 가입자와 소셜 가입자의 구분이 프론트엔드 전역 상태에 반영되지 않던 문제를 해결하고, 백엔드의 `social: boolean` 플래그를 활용하여 소셜 로그인 회원이 마이페이지의 '이메일 변경' 메뉴에 접근하는 것을 원천 차단했습니다.
- UI 레벨에서의 메뉴 은닉(Hiding) 처리와 더불어, URL을 통한 직접 접근 시 강제 리다이렉트(Route Guard) 로직을 추가하여 보안과 사용자 경험을 개선했습니다.
- 관련 이슈: #467 (refactor/467-mypage-social)

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가 (소셜 유저 라우트 가드 추가)
- [x] 버그 수정 (React 18 Strict Mode 중복 토스트 렌더링 방지)
- [x] 코드 리팩토링 (인터페이스 타입 명시 및 사이드바 렌더링 로직 개선)
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

## 📸 스크린샷 (Screenshots)
| 데스크탑 뷰 (일반 회원) | 데스크탑 뷰 (소셜 회원) |
| :---: | :---: |
| [이메일 변경 메뉴 노출 O] | [이메일 변경 메뉴 노출 X] |

| 모바일 뷰 (일반 회원) | 모바일 뷰 (소셜 회원) |
| :---: | :---: |
| [이메일 변경 메뉴 노출 O] | [이메일 변경 메뉴 노출 X] |

## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [x] 린트 에러가 없나요? (`pnpm lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

---

## 🔬 세부 구현 내용 및 시각화 (Detailed Implementation)

이번 작업은 프론트엔드의 **[ 1. 타입 확장 ] → [ 2. UI 필터링 ] → [ 3. 라우팅 가드 ]** 3단계로 견고하게 설계되었습니다.

### 1. 타입 및 전역 상태 확장 (`src/types/auth.ts`, `src/types/member.ts`)
백엔드 `/api/v1/members/me` 응답 객체에 새롭게 추가된 `social: boolean` 필드를 TypeScript가 인식할 수 있도록 타입을 확장했습니다. 이를 통해 Zustand 전역 스토어인 `useAuthStore`에서 안전하게 `user.social` 값에 접근할 수 있게 되었습니다.

```mermaid
classDiagram
    class ApiResponse_ProfileResponse {
        +boolean isSuccess
        +Result result
    }
    class User {
        +string email
        +string nickname
        +boolean profileCompleted
        +boolean social
    }
    class useAuthStore {
        +User user
        +login(User)
        +logout()
    }
    ApiResponse_ProfileResponse ..> User : Map to global state
    User --* useAuthStore : Stored in
```

### 2. UI 메뉴 필터링 (`SettingsSidebar.tsx`, `SettingsPageClient.tsx`)
사용자가 마이페이지에 진입했을 때, 현재 전역 상태에 저장된 `user.social` 플래그를 확인하여 메뉴 렌더링을 동적으로 처리합니다.

- 데스크탑 사이드바와 모바일 메인 설정 화면 모두 `SETTINGS_MENU` 상수를 기반으로 렌더링됩니다.
- 렌더링 직전 `.filter()` 메서드를 사용하여 `item.href === "/setting/email"` 이면서 `user.social === true` 인 경우 해당 항목을 배열에서 제외하여 자연스럽게 UI에서 은닉시켰습니다.

```mermaid
flowchart TD
    A[설정 페이지 진입] --> B{user.social === true ?}
    B -- Yes (카카오 등) --> C[filter: '이메일 변경' 메뉴 삭제]
    B -- No (일반 이메일) --> D[filter: '이메일 변경' 메뉴 유지]
    C --> E[설정 메뉴 렌더링 완료]
    D --> E
```

### 3. URL 직접 진입 차단 및 Guard 최적화 (`EmailChangePageClient.tsx`)
UI에서 메뉴를 감췄더라도, 악의적(혹은 실수)으로 주소창에 `/setting/email`을 직접 입력하여 접근하는 것을 차단하기 위한 클라이언트 사이드 가드를 추가했습니다.

- 컴포넌트 마운트 시 `useEffect`를 통해 `user.social` 값을 검사합니다.
- 조건에 부합할 경우 `react-hot-toast`로 에러 메시지를 띄우고 `router.replace("/setting")`로 튕겨냅니다.
- **[버그 해결]**: React 18 Strict Mode 환경에서 `useEffect`가 두 번 실행되어 에러 토스트 알림이 2개씩 겹쳐 뜨는 현상을 방지하고자, `useRef(false)`를 활용해 **최초 1회만 토스트가 발생**하도록 최적화했습니다.

```mermaid
sequenceDiagram
    actor User
    participant Router as Next.js Router
    participant EmailPage as EmailChangePageClient
    participant Toast as react-hot-toast
    
    User->>Router: GET /setting/email (URL 직접 입력)
    Router->>EmailPage: 컴포넌트 렌더링
    EmailPage->>EmailPage: useEffect 실행
    alt user.social == true
        EmailPage->>Toast: error("소셜 로그인 회원은 이메일을 변경할 수 없습니다.")
        Note right of EmailPage: useRef를 사용해 중복 토스트 방지
        EmailPage->>Router: router.replace("/setting")
        Router-->>User: /setting (설정 메인) 화면 노출
    else user.social == false
        EmailPage-->>User: 이메일 변경 화면 정상 렌더링
    end
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social sign-in users now see a simplified Settings menu with the email option hidden.
  * Attempting to access email change settings with a social login now shows an error message and returns to Settings.

* **Bug Fixes**
  * Improved consistency across Settings navigation so unavailable options are no longer shown for applicable accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->