### PR TITLE
fix: align book story action buttons

### DIFF
--- a/src/components/base-ui/Admin/stories/bookstory_detail.tsx
+++ b/src/components/base-ui/Admin/stories/bookstory_detail.tsx
@@ -240,13 +240,13 @@ export default function BookstoryDetail({
         </div>
 
         {/* 좋아요/공유 */}
-        <div className="flex flex-col gap-6">
+        <div className="flex w-[132px] shrink-0 flex-col items-start gap-5 pt-1">
           <div
             onClick={(e) => {
               e.stopPropagation();
               onLikeClick?.(e);
             }}
-            className="flex items-center gap-2 cursor-pointer hover:bg-gray-100 p-1 rounded-full transition-colors"
+            className="flex h-8 w-full items-center gap-2 rounded-full p-1 text-left transition-colors hover:bg-gray-100 cursor-pointer"
           >
             <Image src={heartIcon} alt="heart" width={20} height={20} />
             <span
@@ -258,7 +258,7 @@ export default function BookstoryDetail({
             </span>
           </div>
           <div
-            className="flex items-center gap-2 cursor-pointer"
+            className="flex h-8 w-full items-center gap-2 rounded-full p-1 text-left transition-colors hover:bg-gray-100 cursor-pointer"
             onClick={handleShare}
           >
             <Image src="/share.svg" alt="share" width={20} height={20} />

--- a/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
+++ b/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
@@ -241,19 +241,19 @@ export default function BookstoryDetail({
         </div>
 
         {/* 좋아요/공유 */}
-        <div className="flex flex-col gap-6">
+        <div className="flex w-[132px] shrink-0 flex-col items-start gap-5 pt-1">
           <div
             onClick={(e) => {
               e.stopPropagation();
               onLikeClick?.(e);
             }}
-            className="flex items-center gap-2 cursor-pointer hover:bg-gray-100 p-1 rounded-full transition-colors"
+            className="flex h-8 w-full items-center gap-2 rounded-full p-1 text-left transition-colors hover:bg-gray-100 cursor-pointer"
           >
             <Image src={heartIcon} alt="heart" width={20} height={20} />
             <span className={`body_1_2 ${likedByMe ? 'text-primary-2' : 'text-Gray-5'}`}>좋아요 {likeCount}</span>
           </div>
           <div
-            className="flex items-center gap-2 cursor-pointer"
+            className="flex h-8 w-full items-center gap-2 rounded-full p-1 text-left transition-colors hover:bg-gray-100 cursor-pointer"
             onClick={handleShare}
           >
             <Image src="/share.svg" alt="share" width={20} height={20} />


### PR DESCRIPTION
## 📌 개요 (Summary)
- 책이야기 상세 화면에서 모바일 구간의 좋아요/공유하기 버튼 정렬이 맞지 않는 문제를 수정했습니다.
- 사용자 상세와 관리자 상세 컴포넌트 모두 동일하게 반영했습니다.

## 🛠 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명:)

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [x] 린트 에러가 없나요? (`npm run lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

## 🔍 수동 확인 필요
- 모바일 책이야기 상세에서 좋아요/공유하기 아이콘과 텍스트 시작점이 같은 세로축으로 정렬되는지 확인
- 사용자 상세와 관리자 상세 모두 동일하게 표시되는지 확인