### PR TITLE
fix : 관리자 화면 변경

### DIFF
--- a/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/edit/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/edit/page.tsx
@@ -217,7 +217,7 @@ export default function EditBookshelfPage() {
       });
 
       toast.success('책장 수정 완료!');
-      runWithoutGuard(() => router.push(`/groups/${clubId}/bookcase`));
+      runWithoutGuard(() => router.push(`/groups/${clubId}/bookcase/${meetingId}`));
     } catch (e: unknown) {
       console.error(e);
       toast.error(getBookshelfErrorMessage(e, '책장 수정에 실패했습니다.'));

--- a/src/components/base-ui/Bookcase/ItemMoreMenu.tsx
+++ b/src/components/base-ui/Bookcase/ItemMoreMenu.tsx
@@ -60,7 +60,7 @@ export default function ItemMoreMenu({
       {open && (
         <div
           className="
-            absolute right-0 top-full mt-2
+            absolute right-0 bottom-full mb-2
             w-34
             rounded-lg
             border border-Subbrown-4

--- a/src/components/base-ui/Bookcase/bookid/StarRating.tsx
+++ b/src/components/base-ui/Bookcase/bookid/StarRating.tsx
@@ -34,7 +34,7 @@ export function StarRating({
     return (
       <div key={i} className={`relative shrink-0 ${starClassName}`}>
         {/* 바탕: 빈 별 */}
-        <StarSvg className={`absolute inset-0 ${starClassName} text-Subbrown-3`} />
+        <StarSvg className={`absolute inset-0 ${starClassName} text-Gray-2`} />
 
         {/* 반 별 */}
         {half && (
@@ -91,7 +91,7 @@ export function StarSelector({
             aria-label={`${i + 1}점 선택`}
           >
             {/* 빈 별 */}
-            <StarSvg className={`absolute inset-0 ${starClassName} text-Subbrown-3`} />
+            <StarSvg className={`absolute inset-0 ${starClassName} text-Gray-2`} />
 
             {/* 반 별 */}
             {half && (


### PR DESCRIPTION
## 📌 개요 (Summary)
- 관리자 모임 관리 화면의 API 호출 계약을 백엔드 응답/요청 스펙에 맞게 정리했습니다.
- 관련 이슈: #475

## 🛠 변경 사항 (Changes)
- [x] 버그 수정
- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

- 관리자 모임 목록/활동 멤버 API에서 백엔드가 받지 않는 `size` 파라미터 제거
- 관리자 모임 목록과 활동 멤버 조회의 `page`를 1-based 기준으로 통일
- 검색어를 `URLSearchParams`로 인코딩하도록 수정
- `ownerEmail`이 `null`인 경우 화면에 `-`로 표시
- 활동 멤버 역할 타입을 백엔드 응답에 맞춰 `STAFF`로 수정
- 모임 수정 API 응답 타입을 실제 응답인 `string`으로 정리

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [x] 린트 에러가 없나요? (`pnpm lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

> 참고: 전체 `npm run lint`는 기존 unrelated lint 에러로 실패합니다. 이번 변경 파일 대상 ESLint와 `git diff --check`는 통과했습니다.