### PR TITLE
7/8 QA 수정

### DIFF
--- a/src/app/(main)/groups/[id]/admin/applicant/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/applicant/page.tsx
@@ -9,6 +9,7 @@ import { useInfiniteClubMembersQuery } from '@/hooks/queries/useClubMemberQuerie
 import { useUpdateClubMemberStatusMutation } from '@/hooks/mutations/useClubMemberMutations';
 import type { ClubMemberItem } from '@/types/groups/clubMembers';
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import MobileBackButton from '@/components/common/MobileBackButton';
 
 type ActionType = 'delete' | 'approve';
 
@@ -235,17 +236,7 @@ export default function AdminApplicantPage() {
 
   return (
     <div className="w-full">
-      <div className="t:hidden px-2.5 py-3">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="flex items-center gap-2 text-Gray-7 body_1_2"
-        >
-          <Image src="/back.svg" alt="뒤로가기" width={12} height={12} />
-          <span>뒤로가기</span>
-        </button>
-      </div>
-      <div className="t:hidden border-b border-Gray-2" />
+      <MobileBackButton onClick={() => router.back()} />
 
       <div className="px-4.5 t:px-10 d:px-4">
         <div className="mx-auto w-full max-w-260 py-6">

--- a/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/edit/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/edit/page.tsx
@@ -18,6 +18,7 @@ import { usePatchBookshelfMutation } from '@/hooks/mutations/useClubsBookshelfMu
 import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard';
 import { INPUT_LIMITS } from '@/constants/inputLimits';
 import { clampTextToLimit, isTextOverLimit } from '@/utils/inputLimit';
+import MobileBackButton from '@/components/common/MobileBackButton';
 
 const TAGS = [
   { label: '여행', colorClass: 'bg-Secondary-2' },
@@ -249,18 +250,7 @@ export default function EditBookshelfPage() {
 
   return (
     <div className="w-full">
-      {/* 뒤로가기 - 모바일에서만 */}
-      <div className="t:hidden px-2.5 py-3">
-        <button
-          type="button"
-          onClick={handleBack}
-          className="flex items-center gap-2 text-Gray-7 body_1_2"
-        >
-          <Image src="/back.svg" alt="뒤로가기" width={12} height={12} />
-          <span>뒤로가기</span>
-        </button>
-      </div>
-      <div className="t:hidden border-b border-Gray-2" />
+      <MobileBackButton onClick={handleBack} />
 
       <div className="py-4 t:py-6 px-2.5 t:px-10">
         <div className="flex justify-center">

--- a/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/page.tsx
@@ -67,7 +67,7 @@ export default function AdminMeetingTeamManagePage() {
         clubMemberId: cm.clubMemberId,
         memberInfo: {
           nickname: cm.memberInfo?.nickname ?? "",
-          profileImageUrl: cm.memberInfo?.profileImageUrl ?? "",
+          profileImageUrl: cm.memberInfo?.profileImageUrl ?? null,
         },
         teamNumber: cm.teamKey?.teamNumber ?? null,
       })) ?? [];

--- a/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/[meetingId]/page.tsx
@@ -12,10 +12,10 @@ import {
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
 
 import MemberPool from "@/components/base-ui/Bookcase/Admin/bookdetailgrouping/MemberPool";
 import TeamBoard from "@/components/base-ui/Bookcase/Admin/bookdetailgrouping/TeamBoard";
+import MobileBackButton from "@/components/common/MobileBackButton";
 
 
 import { useMeetingMembersQuery} from "@/hooks/queries/useMeetingQueries"; 
@@ -73,6 +73,7 @@ export default function AdminMeetingTeamManagePage() {
       })) ?? [];
 
     setMembers(mappedMembers);
+    setIsInitialized(true);
   }, [data]);
 
   const unassigned = useMemo(
@@ -190,24 +191,7 @@ export default function AdminMeetingTeamManagePage() {
       autoScroll
     >
       <div className="w-full">
-        {/* 모바일 전용 뒤로가기 바 */}
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="
-            t:hidden
-            w-full
-            flex items-center gap-2
-            px-[10px] py-[12px]
-            border-b border-Gray-2
-            text-Gray-7 body_1_2
-          "
-        >
-          <div className="relative w-[12px] h-[12px] shrink-0">
-            <Image src="/Polygon7.svg" alt="뒤로가기" fill className="object-contain" priority />
-          </div>
-          <span>뒤로가기</span>
-        </button>
+        <MobileBackButton onClick={() => router.back()} />
 
         <div className="w-full t:px-10">
           <div

--- a/src/app/(main)/groups/[id]/admin/bookcase/new/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/bookcase/new/page.tsx
@@ -14,6 +14,7 @@ import { CreateBookshelfRequest } from '@/types/bookshelf';
 import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard';
 import { INPUT_LIMITS } from '@/constants/inputLimits';
 import { clampTextToLimit, isTextOverLimit } from '@/utils/inputLimit';
+import MobileBackButton from '@/components/common/MobileBackButton';
 
 const TAGS = [
   { label: '여행', colorClass: 'bg-Secondary-2' },
@@ -200,18 +201,7 @@ export default function NewBookshelfPage() {
 
   return (
     <div className="w-full">
-      {/* 뒤로가기 - 모바일에서만 */}
-      <div className="t:hidden px-2.5 py-3">
-        <button
-          type="button"
-          onClick={handleBack}
-          className="flex items-center gap-2 text-Gray-7 body_1_2"
-        >
-          <Image src="/back.svg" alt="뒤로가기" width={12} height={12} />
-          <span>뒤로가기</span>
-        </button>
-      </div>
-      <div className="t:hidden border-b border-Gray-2" />
+      <MobileBackButton onClick={handleBack} />
 
       <div className="py-4 t:py-6 px-2.5 t:px-10">
         <div className="flex justify-center">

--- a/src/app/(main)/groups/[id]/admin/notice/new/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/notice/new/page.tsx
@@ -15,6 +15,7 @@ import { useCreateClubNoticeMutation } from "@/hooks/mutations/useClubNotificati
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { clampTextToLimit, isTextOverLimit } from "@/utils/inputLimit";
+import MobileBackButton from "@/components/common/MobileBackButton";
 
 type Book = {
   id: number; // meetingId로 사용
@@ -63,11 +64,10 @@ export default function NewNoticePage() {
     enabled: Number.isFinite(clubId) && isBookshelfModalOpen,
   });
 
-  const shelves =
-  shelvesQuery.data?.pages.flatMap((p: any) => p.bookShelfInfoList) ?? [];
-
   const modalBooks: Book[] = useMemo(() => {
-    return shelves.map((s: any) => ({
+    const shelves = shelvesQuery.data?.pages.flatMap((page) => page.bookShelfInfoList) ?? [];
+
+    return shelves.map((s) => ({
       id: s.meetingInfo.meetingId,
       title: s.bookInfo.title,
       author: s.bookInfo.author,
@@ -79,7 +79,7 @@ export default function NewNoticePage() {
       description: "",
       imageUrl: s.bookInfo.imgUrl ?? null, 
     }));
-  }, [shelves]);
+  }, [shelvesQuery.data]);
 
   const { mutateAsync: createNotice, isPending } = useCreateClubNoticeMutation();
 
@@ -103,7 +103,7 @@ export default function NewNoticePage() {
       selectedBook ||
       imageFiles.length > 0
   );
-  const { runWithoutGuard } = useUnsavedChangesGuard({
+  const { confirmNavigation, runWithoutGuard } = useUnsavedChangesGuard({
     isDirty,
     variant: "create",
     title: "작성 중인 공지사항이 있어요",
@@ -131,6 +131,10 @@ export default function NewNoticePage() {
   };
 
   const handleRemoveBook = () => setSelectedBook(null);
+
+  const handleBack = () => {
+    confirmNavigation(() => router.back());
+  };
 
   const handleVoteItemChange = (index: number, value: string) => {
     setVoteItems((prev) =>
@@ -318,10 +322,10 @@ export default function NewNoticePage() {
       toast.dismiss(tid);
       toast.success("공지사항 등록 성공");
       runWithoutGuard(() => router.push(`/groups/${groupId}/notice`));
-    } catch (e: any) {
+    } catch (e: unknown) {
       toast.dismiss(tid);
 
-      const msg = e?.message ?? "";
+      const msg = e instanceof Error ? e.message : "";
       if (msg.includes("isPinned") || msg.includes("pinned") || msg.includes("고정")) {
         toast.error("고정 공지는 최대 5개까지 가능합니다.");
         return;
@@ -336,7 +340,7 @@ export default function NewNoticePage() {
 
   return (
     <div className="w-full">
-      <div className="t:hidden border-b border-Gray-2" />
+      <MobileBackButton onClick={handleBack} />
 
       <div className="py-4 t:pt-6 px-3 t:px-10">
         <div className="flex justify-center">

--- a/src/app/(main)/groups/[id]/admin/notice/new/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/notice/new/page.tsx
@@ -354,7 +354,7 @@ export default function NewNoticePage() {
                 <button
                   type="button"
                   onClick={handleRemoveBook}
-                  className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center"
+                  className="absolute right-2 top-2 flex h-6 w-6 cursor-pointer items-center justify-center"
                   aria-label="선택한 책 제거"
                 >
                   <Image
@@ -465,6 +465,7 @@ export default function NewNoticePage() {
                                 flex items-center justify-center
                                 gap-2
                                 body_1_2 text-Gray-6
+                                cursor-pointer
                                 hover:text-Gray-7
                               "
                             >
@@ -477,7 +478,7 @@ export default function NewNoticePage() {
                         <div className="flex flex-col gap-4">
                           <button
                             type="button"
-                            className="flex items-center gap-3 text-left"
+                            className="flex cursor-pointer items-center gap-3 text-left"
                             onClick={() => setIsMultiple((prev) => !prev)}
                           >
                             <div className="relative w-6 h-6 rounded-full border border-Subbrown-3 bg-White">
@@ -492,7 +493,7 @@ export default function NewNoticePage() {
 
                           <button
                             type="button"
-                            className="flex items-center gap-3 text-left"
+                            className="flex cursor-pointer items-center gap-3 text-left"
                             onClick={() => setIsAnonymous((prev) => !prev)}
                           >
                             <div className="relative w-6 h-6 rounded-full border border-Subbrown-3 bg-White">
@@ -515,7 +516,7 @@ export default function NewNoticePage() {
                                   dateInputRef.current?.focus();
                                 });
                               }}
-                              className="flex items-center gap-3 text-left"
+                              className="flex cursor-pointer items-center gap-3 text-left"
                             >
                               <div className="relative w-6 h-6">
                                 <Image
@@ -545,7 +546,7 @@ export default function NewNoticePage() {
                                       timeInputRef.current?.focus();
                                     });
                                   }}
-                                  className="h-[44px] rounded-[8px] border border-Subbrown-4 bg-White px-4 body_1_2 text-Gray-7 outline-none"
+                                  className="h-[44px] cursor-pointer rounded-[8px] border border-Subbrown-4 bg-White px-4 body_1_2 text-Gray-7 outline-none"
                                 />
                                 <input
                                   ref={timeInputRef}
@@ -557,7 +558,7 @@ export default function NewNoticePage() {
                                       setIsDeadlineEditing(false),
                                     );
                                   }}
-                                  className="h-[44px] rounded-[8px] border border-Subbrown-4 bg-White px-4 body_1_2 text-Gray-7 outline-none"
+                                  className="h-[44px] cursor-pointer rounded-[8px] border border-Subbrown-4 bg-White px-4 body_1_2 text-Gray-7 outline-none"
                                 />
                               </div>
                             )}
@@ -590,7 +591,7 @@ export default function NewNoticePage() {
                               <button
                                 type="button"
                                 onClick={() => handleRemoveImage(index)}
-                                className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-black/60"
+                                className="absolute right-2 top-2 flex h-6 w-6 cursor-pointer items-center justify-center rounded-full bg-black/60"
                                 aria-label="이미지 삭제"
                               >
                                 <span className="text-[12px] text-White leading-none">
@@ -610,7 +611,7 @@ export default function NewNoticePage() {
                     <button
                       type="button"
                       onClick={() => setIsPinned((prev) => !prev)}
-                      className={`flex items-center gap-2 body_1_2 transition-all ${
+                      className={`flex cursor-pointer items-center gap-2 body_1_2 transition-all ${
                         isPinned ? "text-Gray-7" : "text-Gray-4"
                       }`}
                     >
@@ -629,7 +630,7 @@ export default function NewNoticePage() {
                     <button
                       type="button"
                       onClick={() => setIsVoteEnabled((prev) => !prev)}
-                      className={`flex items-center gap-2 body_1_2 transition-all ${
+                      className={`flex cursor-pointer items-center gap-2 body_1_2 transition-all ${
                         isVoteEnabled ? "text-Gray-7" : "text-Gray-4"
                       }`}
                     >
@@ -648,7 +649,7 @@ export default function NewNoticePage() {
                     <button
                       type="button"
                       onClick={() => setIsBookshelfModalOpen(true)}
-                      className={`flex items-center gap-2 body_1_2 transition-all ${
+                      className={`flex cursor-pointer items-center gap-2 body_1_2 transition-all ${
                         isBookshelfActive ? "text-Gray-7" : "text-Gray-4"
                       }`}
                     >
@@ -667,7 +668,7 @@ export default function NewNoticePage() {
                     <button
                       type="button"
                       onClick={handleImageFile}
-                      className={`flex items-center gap-2 body_1_2 transition-all ${
+                      className={`flex cursor-pointer items-center gap-2 body_1_2 transition-all ${
                         hasImages ? "text-Gray-7" : "text-Gray-4"
                       }`}
                     >
@@ -701,14 +702,15 @@ export default function NewNoticePage() {
                 <button
                   type="button"
                   onClick={() => toast("임시저장은 미구현입니다.")}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3"
+                  className="flex px-4 py-3 w-[132px] h-[44px] cursor-pointer justify-center items-center rounded-lg border border-primary-1 text-primary-3 body_1_2 bg-background transition-colors hover:bg-Subbrown-3"
                 >
                   임시저장
                 </button>
                 <button
                   type="button"
                   onClick={handleSubmit}
-                  className="flex px-4 py-3 w-[132px] h-[44px] justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 hover:bg-primary-1 transition-colors"
+                  disabled={isPending}
+                  className="flex px-4 py-3 w-[132px] h-[44px] cursor-pointer justify-center items-center rounded-lg bg-primary-2 text-White body_1_2 transition-colors hover:bg-primary-1 disabled:cursor-not-allowed disabled:bg-Gray-2 disabled:hover:bg-Gray-2"
                 >
                   등록
                 </button>

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/BookDetailPageClient.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/BookDetailPageClient.tsx
@@ -56,7 +56,7 @@ export default function BookDetailPageClient() {
   const { user } = useAuthStore();
 
   const myName = user?.nickname ?? "My_Name";
-  const myProfileImageUrl = user?.profileImageUrl ?? "/profile4.svg";
+  const myProfileImageUrl = user?.profileImageUrl;
 
   const [isDebateWriting, setIsDebateWriting] = useState(false);
   const [isReviewWriting, setIsReviewWriting] = useState(false);
@@ -306,7 +306,6 @@ export default function BookDetailPageClient() {
               <DebateSection
                 myName={myName}
                 myProfileImageUrl={myProfileImageUrl}
-                defaultProfileUrl="/profile4.svg"
                 isStaff={isStaff}
                 isWriting={isDebateWriting}
                 onToggleWriting={() => setIsDebateWriting((v) => !v)}
@@ -354,7 +353,6 @@ export default function BookDetailPageClient() {
               <ReviewSection
                 myName={myName}
                 myProfileImageUrl={myProfileImageUrl}
-                defaultProfileUrl="/profile4.svg"
                 isStaff={isStaff}
                 isWriting={isReviewWriting}
                 onToggleWriting={() => setIsReviewWriting((v) => !v)}

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/DebateSection.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/DebateSection.tsx
@@ -8,6 +8,7 @@ import LongtermChatInput from "@/components/base-ui/LongtermInput";
 import DebateList, { DebateItem } from "@/components/base-ui/Group/DebateList";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   myName: string;
@@ -35,7 +36,7 @@ type Props = {
 export default function DebateSection({
   myName,
   myProfileImageUrl,
-  defaultProfileUrl = "/profile4.svg",
+  defaultProfileUrl,
 
   isStaff,
 
@@ -54,7 +55,7 @@ export default function DebateSection({
 
   onClickAuthor,
 }: Props) {
-  const profileSrc = myProfileImageUrl || defaultProfileUrl;
+  const profileSrc = getProfileImageSrc(myProfileImageUrl ?? defaultProfileUrl);
   const [draftText, setDraftText] = useState("");
   const { ref: loadMoreRef, inView } = useInView({
     rootMargin: "300px 0px",

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/MeetingTabSection.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/MeetingTabSection.tsx
@@ -76,7 +76,7 @@ export default function MeetingTabSection({ clubId, meetingId, onManageTeamsClic
       group?.members.map((m) => ({
         id: String(m.clubMemberId),
         name: m.memberInfo.nickname,
-        profileImageUrl: m.memberInfo.profileImageUrl,
+        profileImageUrl: m.memberInfo.profileImageUrl ?? undefined,
       })) ?? [];
 
     return {

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/MeetingTabSection.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/MeetingTabSection.tsx
@@ -76,7 +76,7 @@ export default function MeetingTabSection({ clubId, meetingId, onManageTeamsClic
       group?.members.map((m) => ({
         id: String(m.clubMemberId),
         name: m.memberInfo.nickname,
-        profileImageUrl: m.memberInfo.profileImageUrl || "/profile4.svg",
+        profileImageUrl: m.memberInfo.profileImageUrl,
       })) ?? [];
 
     return {

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/ReviewSection.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/ReviewSection.tsx
@@ -10,6 +10,7 @@ import ReviewList, { ReviewItem } from "@/components/base-ui/Bookcase/bookid/Rev
 import { StarSelector } from "@/components/base-ui/Bookcase/bookid/StarRating";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   myName: string;
@@ -38,7 +39,7 @@ type Props = {
 export default function ReviewSection({
   myName,
   myProfileImageUrl,
-  defaultProfileUrl = "/profile4.svg",
+  defaultProfileUrl,
 
   isStaff,
 
@@ -57,7 +58,7 @@ export default function ReviewSection({
 
   onClickAuthor,
 }: Props) {
-  const profileSrc = myProfileImageUrl || defaultProfileUrl;
+  const profileSrc = getProfileImageSrc(myProfileImageUrl ?? defaultProfileUrl);
   const [newRating, setNewRating] = useState<number>(0);
   const [draftText, setDraftText] = useState("");
   const { confirmNavigation } = useUnsavedChangesGuard({

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/meeting/MeetingPageClient.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/meeting/MeetingPageClient.tsx
@@ -17,6 +17,7 @@ import type { MeetingTopicItem } from "@/types/groups/meetingTopics";
 import MeetingTeamMemberPopover from "@/components/base-ui/Bookcase/MeetingTeamMemberPopover";
 import toast from "react-hot-toast";
 import { useMeetingRealtime } from "@/hooks/realtime/useMeetingRealtime";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type TeamViewModel = {
   teamId: number;
@@ -26,7 +27,6 @@ type TeamViewModel = {
 };
 
 const CHECKED_BG = "#F7FEF3";
-const DEFAULT_PROFILE = "/profile4.svg";
 
 const makePresentationPendingKey = (teamId: number, topicId: number) =>
   `${teamId}:${topicId}`;
@@ -35,13 +35,6 @@ function teamNumberToLabel(teamNumber: number) {
   const code = 64 + teamNumber;
   if (code >= 65 && code <= 90) return `${String.fromCharCode(code)}조`;
   return `${teamNumber}조`;
-}
-
-function normalizeSrc(src?: string | null) {
-  if (!src || src.trim() === "") return DEFAULT_PROFILE;
-  if (src.startsWith("http")) return src;
-  if (src.startsWith("/")) return src;
-  return `/${src}`;
 }
 
 function sortSelectedFirstStable(list: MeetingTopicItem[]) {
@@ -526,7 +519,7 @@ export default function MeetingPageClient() {
                   </div>
                 ) : (
                   visibleTopics.map((topic) => {
-                    const profileSrc = normalizeSrc(topic.author.profileImageUrl);
+                    const profileSrc = getProfileImageSrc(topic.author.profileImageUrl);
                     const isPending =
                       selectedTeamId !== null &&
                       pendingPresentationKeys.has(

--- a/src/app/(main)/groups/create/CreateGroupPageClient.tsx
+++ b/src/app/(main)/groups/create/CreateGroupPageClient.tsx
@@ -28,6 +28,7 @@ import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { clampTextToLimit, isTextOverLimit } from "@/utils/inputLimit";
 
 type NameCheckState = "idle" | "checking" | "available" | "duplicate";
+type ImageUploadStatus = "idle" | "uploading" | "success" | "error";
 type SnsLink = { label: string; url: string };
 
 function cx(...classes: (string | false | null | undefined)[]) {
@@ -35,11 +36,11 @@ function cx(...classes: (string | false | null | undefined)[]) {
 }
 
 const PRIMARY_FILLED_BUTTON_CLASS =
-  "bg-primary-1 text-White transition-colors hover:bg-primary-3 disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed";
+  "bg-primary-1 text-White cursor-pointer transition-colors hover:bg-primary-3 disabled:bg-Gray-2 disabled:hover:bg-Gray-2 disabled:cursor-not-allowed";
 const SELECTABLE_BUTTON_ACTIVE_CLASS =
-  "bg-primary-1 border-primary-1 text-White transition-colors hover:bg-primary-3 hover:border-primary-3";
+  "bg-primary-1 border-primary-1 text-White cursor-pointer transition-colors hover:bg-primary-3 hover:border-primary-3";
 const SELECTABLE_BUTTON_IDLE_CLASS =
-  "bg-Subbrown-4 border-Subbrown-3 text-primary-3 transition-colors hover:bg-Subbrown-3";
+  "bg-Subbrown-4 border-Subbrown-3 text-primary-3 cursor-pointer transition-colors hover:bg-Subbrown-3";
 
 const autoResize = (el: HTMLTextAreaElement) => {
   el.style.height = "0px";
@@ -66,6 +67,7 @@ export default function CreateGroupPageClient() {
   const [isDefaultProfileSelected, setIsDefaultProfileSelected] = useState(false);
   const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
   const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [imageUploadStatus, setImageUploadStatus] = useState<ImageUploadStatus>("idle");
 
   // ✅ 서버에 그대로 보내는 값: open(boolean)
   const [open, setOpen] = useState<boolean | null>(null);
@@ -84,6 +86,7 @@ export default function CreateGroupPageClient() {
   const nameQuery = useClubNameCheckQuery(clubName); // enabled:false라 버튼에서 refetch로만 호출됨
   const uploadImage = useUploadClubImageMutation();
   const createClub = useCreateClubMutation();
+  const isImageUploading = imageUploadStatus === "uploading" || uploadImage.isPending;
 
   const canNext = useMemo(() => {
     if (step === 1)
@@ -94,7 +97,7 @@ export default function CreateGroupPageClient() {
       if (open === null) return false;
 
       // 업로드 모드면 업로드 완료(=profileImageUrl 확보)까지 기다리게
-      if (profileMode === "upload") return Boolean(profileImageUrl) && !uploadImage.isPending;
+      if (profileMode === "upload") return Boolean(profileImageUrl) && !isImageUploading;
 
       // 기본 프로필 모드는 그냥 통과
       return true;
@@ -114,7 +117,7 @@ export default function CreateGroupPageClient() {
     open,
     profileMode,
     profileImageUrl,
-    uploadImage.isPending,
+    isImageUploading,
     selectedCategories,
     selectedParticipants,
     activityArea,
@@ -158,6 +161,9 @@ export default function CreateGroupPageClient() {
 
   // 이미지 선택: 미리보기 + 업로드 + imageUrl 저장
   const pickImage = async (file: File) => {
+    setImageUploadStatus("uploading");
+    setProfileImageUrl(null);
+
     // 로컬 미리보기
     const reader = new FileReader();
     reader.onloadend = () => setSelectedImageUrl(reader.result as string);
@@ -166,9 +172,11 @@ export default function CreateGroupPageClient() {
     try {
       const imageUrl = await uploadImage.mutateAsync(file);
       setProfileImageUrl(imageUrl);
+      setImageUploadStatus("success");
       toast.success("프로필 이미지 업로드 완료");
     } catch {
       setProfileImageUrl(null);
+      setImageUploadStatus("error");
       toast.error("이미지 업로드 실패");
 
       // ✅ 같은 파일 다시 선택 가능하게 input 초기화
@@ -459,7 +467,14 @@ export default function CreateGroupPageClient() {
               <div className="mt-4 flex items-start gap-6">
                 <div className="relative w-[96px] h-[80px] t:w-[194px] t:h-[162px] rounded-[10px] overflow-hidden bg-Subbrown-4 flex items-center justify-center">
                   {selectedImageUrl ? (
-                    <img src={selectedImageUrl} alt="preview" className="w-full h-full object-cover" />
+                    <Image
+                      src={selectedImageUrl}
+                      alt="preview"
+                      fill
+                      sizes="(min-width: 768px) 194px, 96px"
+                      className="object-cover"
+                      unoptimized
+                    />
                   ) : (
                     <>
                       <Image
@@ -490,11 +505,13 @@ export default function CreateGroupPageClient() {
                       setProfileImageUrl(null);
                       setProfileMode("default");
                       setIsDefaultProfileSelected(true);
+                      setImageUploadStatus("idle");
                       if (fileRef.current) fileRef.current.value = "";
                     }}
+                    disabled={isImageUploading}
                     className={cx(
                       "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
-                      "active:opacity-80",
+                      "active:opacity-80 disabled:cursor-not-allowed disabled:opacity-60",
                       profileMode === "default" && isDefaultProfileSelected
                         ? SELECTABLE_BUTTON_ACTIVE_CLASS
                         : SELECTABLE_BUTTON_IDLE_CLASS
@@ -506,13 +523,13 @@ export default function CreateGroupPageClient() {
                   <button
                     type="button"
                     onClick={() => {
-                      setProfileMode("upload");
-                      setIsDefaultProfileSelected(false);
+                      setImageUploadStatus("idle");
                       fileRef.current?.click();
                     }}
+                    disabled={isImageUploading}
                     className={cx(
                       "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
-                      "active:opacity-80",
+                      "active:opacity-80 disabled:cursor-not-allowed disabled:opacity-60",
                       profileMode === "upload"
                         ? SELECTABLE_BUTTON_ACTIVE_CLASS
                         : SELECTABLE_BUTTON_IDLE_CLASS
@@ -536,13 +553,14 @@ export default function CreateGroupPageClient() {
                     }}
                   />
 
-                  {profileMode === "upload" && (
-                    <p className="body_1_4 text-Gray-3">
-                      {uploadImage.isPending
-                        ? "업로드 중..."
-                        : profileImageUrl
-                        ? ""
-                        : "업로드 실패 시 다시 시도"}
+                  {profileMode === "upload" && imageUploadStatus !== "idle" && imageUploadStatus !== "success" && (
+                    <p
+                      className={cx(
+                        "body_1_4",
+                        imageUploadStatus === "error" ? "text-[#FF8045]" : "text-Gray-3"
+                      )}
+                    >
+                      {imageUploadStatus === "uploading" ? "업로드 중..." : "업로드 실패 시 다시 시도"}
                     </p>
                   )}
                 </div>
@@ -752,6 +770,7 @@ export default function CreateGroupPageClient() {
                           rounded-[8px]
                           bg-Gray-1
                           flex items-center justify-center
+                          cursor-pointer
                           hover:bg-Gray-2
                           disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-Gray-1
                         "
@@ -771,6 +790,7 @@ export default function CreateGroupPageClient() {
                     w-full h-[56px] rounded-[8px]
                     bg-Gray-1
                     flex items-center justify-center
+                    cursor-pointer
                     hover:bg-Gray-2
                     disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-Gray-1
                   "

--- a/src/app/(main)/groups/create/CreateGroupPageClient.tsx
+++ b/src/app/(main)/groups/create/CreateGroupPageClient.tsx
@@ -63,6 +63,7 @@ export default function CreateGroupPageClient() {
 
   // Step 2
   const [profileMode, setProfileMode] = useState<"default" | "upload">("default");
+  const [isDefaultProfileSelected, setIsDefaultProfileSelected] = useState(false);
   const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
   const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
 
@@ -488,12 +489,13 @@ export default function CreateGroupPageClient() {
                       setSelectedImageUrl(null);
                       setProfileImageUrl(null);
                       setProfileMode("default");
+                      setIsDefaultProfileSelected(true);
                       if (fileRef.current) fileRef.current.value = "";
                     }}
                     className={cx(
                       "flex justify-center items-center gap-[10px] w-[200px] h-[36px] px-4 py-3 rounded-[8px] border body_1_3",
                       "active:opacity-80",
-                      profileMode === "default"
+                      profileMode === "default" && isDefaultProfileSelected
                         ? SELECTABLE_BUTTON_ACTIVE_CLASS
                         : SELECTABLE_BUTTON_IDLE_CLASS
                     )}
@@ -505,6 +507,7 @@ export default function CreateGroupPageClient() {
                     type="button"
                     onClick={() => {
                       setProfileMode("upload");
+                      setIsDefaultProfileSelected(false);
                       fileRef.current?.click();
                     }}
                     className={cx(
@@ -527,6 +530,7 @@ export default function CreateGroupPageClient() {
                       const f = e.target.files?.[0];
                       if (f) {
                         setProfileMode("upload");
+                        setIsDefaultProfileSelected(false);
                         pickImage(f);
                       }
                     }}

--- a/src/app/(main)/profile/[nickname]/ProfileClient.tsx
+++ b/src/app/(main)/profile/[nickname]/ProfileClient.tsx
@@ -10,12 +10,50 @@ import MeetingList from "@/components/base-ui/Profile/Lists/MeetingList";
 import ProfileBreadcrumb from "@/components/base-ui/Profile/OtherUser/ProfileBreadcrumb";
 import OtherUserProfileTabs from "@/components/base-ui/Profile/OtherUser/OtherUserProfileTabs";
 import type { OtherProfileTabId } from "@/components/base-ui/Profile/OtherUser/OtherUserProfileTabs";
+import { useOtherProfileQuery } from "@/hooks/queries/useMemberQueries";
+import { getProfileAccessErrorMessage } from "@/utils/profileAccess";
+
+const TAB_UNAVAILABLE_TARGET: Record<OtherProfileTabId, string> = {
+  stories: "책 이야기를",
+  library: "서재를",
+  meetings: "모임을",
+};
+
+function ProfileTabUnavailableMessage({
+  activeTab,
+  profileMessage,
+}: {
+  activeTab: OtherProfileTabId;
+  profileMessage: string;
+}) {
+  return (
+    <div className="flex w-full flex-col items-center justify-center gap-2 py-16 text-center">
+      <p className="text-Gray-5 body_1_2 md:subhead_4_1">{profileMessage}</p>
+      <p className="text-Gray-4 body_2_3 md:body_1_2">
+        프로필을 조회할 수 없어 {TAB_UNAVAILABLE_TARGET[activeTab]} 불러올 수 없습니다.
+      </p>
+    </div>
+  );
+}
+
+function ProfileTabLoadingMessage() {
+  return (
+    <div className="flex justify-center items-center py-16 w-full">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#7B6154]"></div>
+    </div>
+  );
+}
 
 export default function ProfileClient({ encodedNickname }: { encodedNickname: string }) {
   const nickname = encodedNickname ? decodeURIComponent(encodedNickname) : "";
   const [activeTab, setActiveTab] = useState<OtherProfileTabId>("stories");
   const router = useRouter();
   const { user, isLoggedIn } = useAuthStore();
+  const profileQuery = useOtherProfileQuery(nickname);
+  const profileAccessErrorMessage = getProfileAccessErrorMessage(profileQuery.error);
+  const profileTabErrorMessage =
+    profileAccessErrorMessage ??
+    (profileQuery.isError ? "프로필 정보를 불러올 수 없습니다." : null);
 
   useEffect(() => {
     if (isLoggedIn && user?.nickname && user.nickname === nickname) {
@@ -33,9 +71,20 @@ export default function ProfileClient({ encodedNickname }: { encodedNickname: st
 
       <div className="flex flex-col items-center w-full max-w-[1440px] px-4 md:px-0 gap-[24px] mt-[10px] md:mt-[72px]">
         <OtherUserProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />
-        {activeTab === "stories" && <BookStoryList nickname={nickname} />}
-        {activeTab === "library" && <LibraryList nickname={nickname} />}
-        {activeTab === "meetings" && <MeetingList nickname={nickname} />}
+        {profileTabErrorMessage ? (
+          <ProfileTabUnavailableMessage
+            activeTab={activeTab}
+            profileMessage={profileTabErrorMessage}
+          />
+        ) : profileQuery.isLoading ? (
+          <ProfileTabLoadingMessage />
+        ) : (
+          <>
+            {activeTab === "stories" && <BookStoryList nickname={nickname} />}
+            {activeTab === "library" && <LibraryList nickname={nickname} />}
+            {activeTab === "meetings" && <MeetingList nickname={nickname} />}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/app/(main)/setting/SettingsPageClient.tsx
+++ b/src/app/(main)/setting/SettingsPageClient.tsx
@@ -54,9 +54,9 @@ export default function SettingsPageClient() {
 
             {/* 세부 메뉴 리스트 (Frame 2087328520) */}
             <div className="flex flex-col items-start gap-[2px] self-stretch">
-              {group.items.map((item: any) => {
-                const isExternal = !!item.isExternal;
-                const href = isExternal ? EXTERNAL_LINKS.INQUIRY_FORM_URL : item.href;
+              {group.items.map((item) => {
+                const isExternal = "isExternal" in item && item.isExternal;
+                const href = isExternal ? EXTERNAL_LINKS.SUPPORT_URL : item.href;
 
                 return (
                   <Link

--- a/src/app/(main)/setting/account-status/AccountStatusPageClient.tsx
+++ b/src/app/(main)/setting/account-status/AccountStatusPageClient.tsx
@@ -45,7 +45,7 @@ export default function AccountStatusPageClient() {
       {/* 2. 탈퇴/비활성화 섹션 */}
       <div className="flex flex-col items-start gap-[24px] self-stretch w-full">
         {/* 두 번째 타이틀 수동 렌더링 */}
-        <div className="-mx-[20px] md:mx-0 w-[calc(100%+40px)] md:w-full">
+        <div className="-mx-[20px] w-[calc(100%+40px)]">
           <SettingsTitle title="탈퇴/비활성화" />
         </div>
 

--- a/src/app/(main)/setting/support/SupportPageClient.tsx
+++ b/src/app/(main)/setting/support/SupportPageClient.tsx
@@ -5,8 +5,8 @@ import { EXTERNAL_LINKS } from "@/constants/links";
 import SettingsDetailLayout from "@/components/base-ui/Settings/SettingsDetailLayout";
 
 export default function SupportPageClient() {
-    const handleOpenForm = () => {
-        window.open(EXTERNAL_LINKS.INQUIRY_FORM_URL, "_blank", "noopener,noreferrer");
+    const handleOpenSupport = () => {
+        window.open(EXTERNAL_LINKS.SUPPORT_URL, "_blank", "noopener,noreferrer");
     };
 
     return (
@@ -39,10 +39,10 @@ export default function SupportPageClient() {
                 {/* 액션 버튼 영역 */}
                 <div className="flex flex-col w-[320px] md:w-[400px] gap-4">
                     <button
-                        onClick={handleOpenForm}
+                        onClick={handleOpenSupport}
                         className="w-full h-[56px] bg-primary-3 text-white rounded-[12px] subhead_4_1 hover:brightness-90 transition-all shadow-md active:scale-[0.98] cursor-pointer"
                     >
-                        문의하기 폼 열기
+                        고객센터 열기
                     </button>
 
                     <div className="flex flex-col gap-2">
@@ -50,7 +50,7 @@ export default function SupportPageClient() {
                             새 창이 열리지 않았나요?
                         </p>
                         <button
-                            onClick={handleOpenForm}
+                            onClick={handleOpenSupport}
                             className="text-primary-3 body_2_1 underline underline-offset-4 hover:text-primary-2 cursor-pointer"
                         >
                             직접 링크로 이동하기

--- a/src/app/(main)/setting/version/page.tsx
+++ b/src/app/(main)/setting/version/page.tsx
@@ -9,7 +9,7 @@ export default function VersionPage() {
     <SettingsDetailLayout title="버전 정보" className="gap-[40px]">
       <div className="flex flex-col items-start gap-[24px] self-stretch">
         <p className="w-full text-Gray-5 text-[14px] font-normal leading-[145%] tracking-[-0.014px] md:body_1_3">
-          버전 업데이트 날짜 : 2026.05.06
+          버전 업데이트 날짜 : 2026.07.08
         </p>
       </div>
     </SettingsDetailLayout>

--- a/src/app/(main)/stories/[id]/StoryDetailClient.tsx
+++ b/src/app/(main)/stories/[id]/StoryDetailClient.tsx
@@ -5,7 +5,7 @@ import StoryNavigation from "@/components/base-ui/BookStory/Detatil/story_naviga
 import CommentSection from "@/components/base-ui/Comment/comment_section_bookcase";
 import BookshelfDeleteConfirmModal from "@/components/base-ui/Bookcase/bookid/BookshelfDeleteConfirmModal";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { isValidUrl } from "@/utils/url";
 import { useParams, useRouter } from "next/navigation";
@@ -28,23 +28,31 @@ export default function StoryDetailClient() {
   const params = useParams();
   const id = params?.id as string;
   const storyId = Number(id);
+  const isInvalidStoryId = !id || Number.isNaN(storyId);
 
-  if (!id || isNaN(storyId)) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[400px]">
-        <h2 className="text-2xl font-bold text-Gray-7 mb-4">잘못된 접근</h2>
-        <p className="text-Gray-5">올바른 경로로 접근해주세요.</p>
-      </div>
-    );
-  }
-
-  const { data: story, isLoading, isError, error } = useStoryDetailQuery(storyId);
+  const { data: story, isLoading, isError, error } = useStoryDetailQuery(
+    isInvalidStoryId ? 0 : storyId
+  );
   const { mutate: toggleLike } = useToggleStoryLikeMutation();
   const { mutate: deleteStory, isPending: isDeletePending } = useDeleteBookStoryMutation();
   const { mutate: toggleFollow } = useToggleFollowMutation();
   const { isLoggedIn, openLoginModal } = useAuthStore();
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (!story?.bookStoryId || window.location.hash !== "#comments") return;
+
+    const timeoutId = window.setTimeout(() => {
+      const commentsSection = document.getElementById("comments");
+      commentsSection?.scrollIntoView({ behavior: "smooth", block: "start" });
+      commentsSection
+        ?.querySelector<HTMLInputElement>("[data-comment-input='true']")
+        ?.focus({ preventScroll: true });
+    }, 100);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [story?.bookStoryId]);
 
   const handleToggleLike = () => {
     if (!isLoggedIn) {
@@ -64,6 +72,15 @@ export default function StoryDetailClient() {
       isFollowing: story!.authorInfo.following
     });
   };
+
+  if (isInvalidStoryId) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px]">
+        <h2 className="text-2xl font-bold text-Gray-7 mb-4">잘못된 접근</h2>
+        <p className="text-Gray-5">올바른 경로로 접근해주세요.</p>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -139,7 +156,11 @@ export default function StoryDetailClient() {
             {story.description}
           </p>
         </div>
-        <div className="border-t-2 border-Gray-1 w-full max-w-[1040px] mx-auto px-5 t:px-6 mt-10 pt-6 pb-10">
+        <div
+          id="comments"
+          tabIndex={-1}
+          className="scroll-mt-6 t:scroll-mt-10 border-t-2 border-Gray-1 w-full max-w-[1040px] mx-auto px-5 t:px-6 mt-10 pt-6 pb-10"
+        >
           <CommentSection
             storyId={story.bookStoryId}
             initialComments={story.comments}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,16 @@
   body {
     font-family: var(--font-sans);
   }
+
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [aria-disabled="true"] {
+    cursor: not-allowed;
+  }
 }
 
 body {

--- a/src/components/base-ui/Admin/stories/bookstory_detail.tsx
+++ b/src/components/base-ui/Admin/stories/bookstory_detail.tsx
@@ -168,7 +168,7 @@ export default function BookstoryDetail({
           <button
             type="button"
             onClick={onSubscribeClick}
-            className={`flex px-4 py-1.5 justify-center items-center rounded-lg text-White text-[12px] font-medium shrink-0 transition-colors ${
+            className={`flex px-4 py-1.5 justify-center items-center rounded-lg text-White text-[12px] font-medium shrink-0 cursor-pointer transition-colors ${
               isFollowing
                 ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
                 : "bg-primary-2 text-White hover:bg-primary-1"

--- a/src/components/base-ui/Admin/users/items/AdminBookStoryCard.tsx
+++ b/src/components/base-ui/Admin/users/items/AdminBookStoryCard.tsx
@@ -100,7 +100,7 @@ export default function BookStoryCard({
               e.stopPropagation();
               onSubscribeClick?.();
             }}
-            className="h-8 whitespace-nowrap rounded-lg bg-primary-2 px-[17px] body_2_1 text-White"
+            className="h-8 whitespace-nowrap rounded-lg bg-primary-2 px-[17px] body_2_1 text-White cursor-pointer transition-colors hover:bg-primary-1"
           >
             {subscribeText}
           </button>

--- a/src/components/base-ui/BookStory/Common/BookStoryInfiniteList.tsx
+++ b/src/components/base-ui/BookStory/Common/BookStoryInfiniteList.tsx
@@ -102,6 +102,10 @@ const BookStoryInfiniteList: React.FC<BookStoryInfiniteListProps> = ({
         e.stopPropagation();
         onToggleLike(story.bookStoryId);
       }}
+      onCommentClick={(e) => {
+        e.stopPropagation();
+        router.push(`/stories/${story.bookStoryId}#comments`);
+      }}
       status={story.status}
       canContinue={story.canContinue}
       onContinueClick={(e) => {

--- a/src/components/base-ui/BookStory/Common/bookstory_card.tsx
+++ b/src/components/base-ui/BookStory/Common/bookstory_card.tsx
@@ -103,7 +103,7 @@ export default function BookStoryCard({
               e.stopPropagation();
               onSubscribeClick?.();
             }}
-            className={`h-8 rounded-lg px-[17px] body_2_1 whitespace-nowrap transition-all active:scale-95 ${isFollowing
+            className={`h-8 rounded-lg px-[17px] body_2_1 whitespace-nowrap cursor-pointer transition-all active:scale-95 ${isFollowing
               ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
               : "bg-primary-2 text-White hover:bg-primary-1"
               }`}

--- a/src/components/base-ui/BookStory/Common/bookstory_card.tsx
+++ b/src/components/base-ui/BookStory/Common/bookstory_card.tsx
@@ -19,6 +19,7 @@ type Props = {
   likedByMe?: boolean;
   onSubscribeClick?: () => void;
   onLikeClick?: (e: React.MouseEvent) => void;
+  onCommentClick?: (e: React.MouseEvent) => void;
   subscribeText?: string;
   isFollowing?: boolean;
   hideSubscribeButton?: boolean;
@@ -31,7 +32,6 @@ type Props = {
 };
 
 export default function BookStoryCard({
-  id,
   authorName,
   profileImgSrc = DEFAULT_PROFILE_IMAGE,
   createdAt,
@@ -44,6 +44,7 @@ export default function BookStoryCard({
   likedByMe = false,
   onSubscribeClick,
   onLikeClick,
+  onCommentClick,
   subscribeText = "구독",
   isFollowing = false,
   hideSubscribeButton = false,
@@ -194,7 +195,13 @@ export default function BookStoryCard({
                   {likeCount}
                 </span>
               </div>
-              <div className="flex flex-1 items-center justify-center gap-[6px] h-[32px]">
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCommentClick?.(e);
+                }}
+                className="flex flex-1 items-center justify-center gap-[6px] h-[32px] cursor-pointer hover:bg-gray-100 transition-colors"
+              >
                 <Image src="/comment.svg" alt="댓글" width={20} height={20} />
                 <span className="text-[12px] font-medium text-Gray-4">
                   {commentCount}
@@ -220,7 +227,13 @@ export default function BookStoryCard({
             </div>
             <div className="h-10 w-[1.8px] mt-2 rounded-full bg-Gray-2" />
             <div className="flex items-center justify-center">
-              <div className="flex items-center justify-center gap-2 pt-1 px-4 h-10">
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCommentClick?.(e);
+                }}
+                className="flex items-center justify-center gap-2 pt-1 cursor-pointer hover:bg-gray-100 transition-colors rounded-full px-4 h-10"
+              >
                 <Image src="/comment.svg" alt="댓글" width={24} height={24} />
                 <span className="body_1_2 text-Gray-4">댓글 {commentCount}</span>
               </div>

--- a/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
+++ b/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
@@ -202,7 +202,7 @@ export default function BookstoryDetail({
           <button
             type="button"
             onClick={onSubscribeClick}
-            className={`flex px-4 py-1.5 justify-center items-center rounded-lg text-White text-[12px] font-medium shrink-0 transition-colors ${isFollowing
+            className={`flex px-4 py-1.5 justify-center items-center rounded-lg text-White text-[12px] font-medium shrink-0 cursor-pointer transition-colors ${isFollowing
               ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
               : "bg-primary-2 text-White hover:bg-primary-1"
               }`}

--- a/src/components/base-ui/Bookcase/Admin/bookdetailgrouping/MemberItem.tsx
+++ b/src/components/base-ui/Bookcase/Admin/bookdetailgrouping/MemberItem.tsx
@@ -2,8 +2,7 @@
 
 import Image from "next/image";
 import type { TeamMember } from "@/types/groups/bookcasedetail";
-
-const DEFAULT_PROFILE = "/profile4.svg";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   member: TeamMember;
@@ -11,7 +10,7 @@ type Props = {
 };
 
 export default function MemberItem({ member, draggable = true }: Props) {
-  const src = member.memberInfo.profileImageUrl ?? DEFAULT_PROFILE;
+  const src = getProfileImageSrc(member.memberInfo.profileImageUrl);
 
   return (
     <div

--- a/src/components/base-ui/Bookcase/Admin/bookdetailgrouping/MemberPool.tsx
+++ b/src/components/base-ui/Bookcase/Admin/bookdetailgrouping/MemberPool.tsx
@@ -6,9 +6,7 @@ import { useRouter } from "next/navigation";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { TeamMember } from "@/types/groups/bookcasedetail";
-import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
-
-const DEFAULT_PROFILE = DEFAULT_PROFILE_IMAGE;
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   unassigned: TeamMember[];
@@ -59,7 +57,7 @@ function DraggableUnassignedCard({
     >
       <div className="relative w-[24px] h-[24px] shrink-0 overflow-hidden rounded-full bg-Subbrown-4">
         <Image
-          src={member.memberInfo.profileImageUrl ?? DEFAULT_PROFILE}
+          src={getProfileImageSrc(member.memberInfo.profileImageUrl)}
           alt="profile"
           fill
           className="object-cover"

--- a/src/components/base-ui/Bookcase/MeetingChatModal.tsx
+++ b/src/components/base-ui/Bookcase/MeetingChatModal.tsx
@@ -7,6 +7,7 @@ import type { ChatTeam } from "@/components/base-ui/Bookcase/ChatTeamSelectModal
 import type { MeetingChatMessageItem } from "@/types/groups/meetingChats";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { clampTextToLimit, isTextOverLimit } from "@/utils/inputLimit";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   isOpen: boolean;
@@ -24,15 +25,6 @@ type Props = {
   isSocketConnected: boolean;
   canSendMessage: boolean;
 };
-
-const DEFAULT_PROFILE = "/profile4.svg";
-
-function normalizeSrc(src?: string | null) {
-  if (!src || src.trim() === "") return DEFAULT_PROFILE;
-  if (src.startsWith("http")) return src;
-  if (src.startsWith("/")) return src;
-  return `/${src}`;
-}
 
 function formatTime(iso: string) {
   const d = new Date(iso);
@@ -300,7 +292,7 @@ export default function MeetingChatModal({
           ) : (
             <div className="flex flex-col gap-3">
               {messages.map((message) => {
-                const profileSrc = normalizeSrc(message.sender.profileImageUrl);
+                const profileSrc = getProfileImageSrc(message.sender.profileImageUrl);
 
                 return (
                   <div key={message.messageId} className="flex items-start gap-3">

--- a/src/components/base-ui/Bookcase/MeetingTeamMemberPopover.tsx
+++ b/src/components/base-ui/Bookcase/MeetingTeamMemberPopover.tsx
@@ -5,20 +5,12 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useOnClickOutside } from "@/hooks/useOnClickOutside";
 import type { MeetingTeamMemberItem } from "@/types/groups/meetingDetail";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   memberCount: number;
   members: MeetingTeamMemberItem[];
 };
-
-const DEFAULT_PROFILE = "/profile4.svg";
-
-function normalizeSrc(src?: string | null) {
-  if (!src || src.trim() === "") return DEFAULT_PROFILE;
-  if (src.startsWith("http")) return src;
-  if (src.startsWith("/")) return src;
-  return `/${src}`;
-}
 
 export default function MeetingTeamMemberPopover({
   memberCount,
@@ -37,7 +29,7 @@ export default function MeetingTeamMemberPopover({
       members.map((member) => ({
         clubMemberId: member.clubMemberId,
         nickname: member.memberInfo.nickname,
-        profileImageUrl: normalizeSrc(member.memberInfo.profileImageUrl),
+        profileImageUrl: getProfileImageSrc(member.memberInfo.profileImageUrl),
       })),
     [members]
   );

--- a/src/components/base-ui/Bookcase/bookid/ReviewList.tsx
+++ b/src/components/base-ui/Bookcase/bookid/ReviewList.tsx
@@ -10,6 +10,7 @@ import { StarRating, StarSelector } from "./StarRating";
 import ItemMoreMenu from "../ItemMoreMenu";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 export type ReviewItem = {
   id: number | string;
@@ -30,8 +31,6 @@ type Props = {
 
   onClickAuthor?: (name: string) => void;
 };
-
-const DEFAULT_PROFILE = "/profile4.svg";
 
 export default function ReviewList({
   items,
@@ -137,7 +136,7 @@ export default function ReviewList({
 
       <div className="w-full flex flex-col gap-[6px]">
         {items.map((item) => {
-          const profileSrc = item.profileImageUrl || DEFAULT_PROFILE;
+          const profileSrc = getProfileImageSrc(item.profileImageUrl);
           const canManage = !!isStaff || !!item.isAuthor;
           const isEditing = editingId != null && String(editingId) === String(item.id);
 

--- a/src/components/base-ui/Bookcase/bookid/TeamDebateSection.tsx
+++ b/src/components/base-ui/Bookcase/bookid/TeamDebateSection.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import React from "react";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 export type TeamDebateItem = {
   id: number | string;
@@ -19,15 +20,6 @@ type Props = {
 
   onToggleCheck: (id: string) => void;
   onSortCheckedFirst: () => void;
-};
-
-const DEFAULT_PROFILE = "/profile4.svg";
-
-const normalizeSrc = (src?: string | null) => {
-  if (!src) return DEFAULT_PROFILE;
-  if (src.startsWith("http")) return src;
-  if (src.startsWith("/")) return src;
-  return `/${src}`; // "profile1.svg" -> "/profile1.svg"
 };
 
 export default function TeamDebateSection({
@@ -84,7 +76,7 @@ export default function TeamDebateSection({
                 {/* 프로필 + 이름 */}
                 <div className="flex items-center gap-3 min-w-0">
                   <Image
-                    src={normalizeSrc(item.profileImageUrl)}
+                    src={getProfileImageSrc(item.profileImageUrl)}
                     alt=""
                     width={28}
                     height={28}

--- a/src/components/base-ui/Bookcase/bookid/TeamMemberItem.tsx
+++ b/src/components/base-ui/Bookcase/bookid/TeamMemberItem.tsx
@@ -2,8 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { isValidUrl } from "@/utils/url";
-import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 type Props = {
   name: string;
@@ -27,7 +26,7 @@ export default function TeamMemberItem({
       <div className="flex items-center gap-[12px]">
         <div className="relative flex h-[40px] w-[40px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-Gray-2">
           <Image
-            src={isValidUrl(profileImageUrl) ? profileImageUrl : DEFAULT_PROFILE_IMAGE}
+            src={getProfileImageSrc(profileImageUrl)}
             alt={name}
             fill
             className="object-cover"

--- a/src/components/base-ui/Comment/comment_input.tsx
+++ b/src/components/base-ui/Comment/comment_input.tsx
@@ -38,6 +38,7 @@ export default function CommentInput({
     <div className="flex items-center gap-3 w-full">
       <input
         type="text"
+        data-comment-input="true"
         value={content}
         onChange={(e) => setContent(clampTextToLimit(e.target.value, maxLength, overLimitMessage))}
         onKeyDown={(e) => e.key === "Enter" && handleSubmit()}

--- a/src/components/base-ui/Group/BookshelfModal.tsx
+++ b/src/components/base-ui/Group/BookshelfModal.tsx
@@ -61,7 +61,7 @@ export default function BookshelfModal({
   return (
     <div className="fixed inset-0 z-50">
       <div
-        className="absolute inset-0 bg-black/40 t:block hidden"
+        className="absolute inset-0 hidden cursor-pointer bg-black/40 t:block"
         onClick={onClose}
       />
 
@@ -82,7 +82,7 @@ export default function BookshelfModal({
             <button
               type="button"
               onClick={onClose}
-              className="t:hidden flex items-center gap-2 body_1_2 text-Gray-7"
+              className="t:hidden flex cursor-pointer items-center gap-2 body_1_2 text-Gray-7"
               aria-label="뒤로가기"
             >
               <Image src="/chevron_left.svg" alt="" width={20} height={20} />
@@ -95,7 +95,7 @@ export default function BookshelfModal({
               type="button"
               onClick={onClose}
               aria-label="닫기"
-              className="hidden t:block"
+              className="hidden cursor-pointer t:block"
             >
               <Image src="/light_close.svg" alt="닫기" width={24} height={24} />
             </button>

--- a/src/components/base-ui/Group/BookshelfModal.tsx
+++ b/src/components/base-ui/Group/BookshelfModal.tsx
@@ -85,7 +85,17 @@ export default function BookshelfModal({
               className="t:hidden flex cursor-pointer items-center gap-2 body_1_2 text-Gray-7"
               aria-label="뒤로가기"
             >
-              <Image src="/chevron_left.svg" alt="" width={20} height={20} />
+              <svg
+                width="9"
+                height="11"
+                viewBox="0 0 9 11"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                className="shrink-0"
+              >
+                <path d="M0 5.19629L9 10.3924V0.00014L0 5.19629Z" fill="#BBAA9B" />
+              </svg>
               뒤로가기
             </button>
 

--- a/src/components/base-ui/Group/DebateList.tsx
+++ b/src/components/base-ui/Group/DebateList.tsx
@@ -8,6 +8,7 @@ import BookshelfDeleteConfirmModal from "@/components/base-ui/Bookcase/bookid/Bo
 import ItemMoreMenu from "../Bookcase/ItemMoreMenu";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
+import { getProfileImageSrc } from "@/utils/profileImage";
 
 export type DebateItem = {
   id: number | string;
@@ -27,8 +28,6 @@ type Props = {
 
   onClickAuthor?: (name: string) => void;
 };
-
-const DEFAULT_PROFILE = "/profile4.svg";
 
 export default function DebateList({
   items,
@@ -127,7 +126,7 @@ export default function DebateList({
 
       <div className="w-full flex flex-col gap-[6px]">
         {items.map((item) => {
-          const profileSrc = item.profileImageUrl || DEFAULT_PROFILE;
+          const profileSrc = getProfileImageSrc(item.profileImageUrl);
           const canManage = !!isStaff || !!item.isAuthor;
           const isEditing = editingId != null && String(editingId) === String(item.id);
 

--- a/src/components/base-ui/Join/steps/ProfileImage/ProfileImageUploader.tsx
+++ b/src/components/base-ui/Join/steps/ProfileImage/ProfileImageUploader.tsx
@@ -30,7 +30,7 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
         <div
           className={`w-[138px] h-[138px] rounded-full overflow-hidden border flex items-center justify-center ${
             isDefaultImage
-              ? "border-Subbrown-3 bg-[#F7F5F3]"
+              ? "border-transparent bg-White"
               : "border-transparent bg-Subbrown-4"
           }`}
         >
@@ -39,9 +39,7 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
             alt="Profile"
             width={138}
             height={138}
-            className={`h-full w-full ${
-              isDefaultImage ? "object-contain p-[18px]" : "object-cover"
-            }`}
+            className="h-full w-full object-cover"
           />
         </div>
         <input

--- a/src/components/base-ui/Join/steps/ProfileImage/ProfileImageUploader.tsx
+++ b/src/components/base-ui/Join/steps/ProfileImage/ProfileImageUploader.tsx
@@ -14,6 +14,11 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
   onReset,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const imageSrc =
+    !profileImage || profileImage.startsWith("/default_profile")
+      ? DEFAULT_PROFILE_IMAGE
+      : profileImage;
+  const isDefaultImage = imageSrc === DEFAULT_PROFILE_IMAGE;
 
   const handleEditClick = () => {
     fileInputRef.current?.click();
@@ -22,13 +27,21 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
   return (
     <div className="flex flex-col items-center gap-[24px] w-full">
       <div className="relative w-[148px] h-[141px]">
-        <div className="w-[138px] h-[138px] rounded-full overflow-hidden bg-Subbrown-4">
+        <div
+          className={`w-[138px] h-[138px] rounded-full overflow-hidden border flex items-center justify-center ${
+            isDefaultImage
+              ? "border-Subbrown-3 bg-[#F7F5F3]"
+              : "border-transparent bg-Subbrown-4"
+          }`}
+        >
           <Image
-            src={profileImage || DEFAULT_PROFILE_IMAGE}
+            src={imageSrc}
             alt="Profile"
             width={138}
             height={138}
-            className="object-cover"
+            className={`h-full w-full ${
+              isDefaultImage ? "object-contain p-[18px]" : "object-cover"
+            }`}
           />
         </div>
         <input

--- a/src/components/base-ui/Join/steps/ProfileSetup/ProfileSetup.tsx
+++ b/src/components/base-ui/Join/steps/ProfileSetup/ProfileSetup.tsx
@@ -3,7 +3,6 @@ import JoinLayout from "../../JoinLayout";
 import JoinButton from "../../JoinButton";
 import JoinInput from "../../JoinInput";
 import { useProfileSetup } from "./useProfileSetup";
-import { useSignup } from "@/contexts/SignupContext";
 
 interface ProfileSetupProps {
   onNext?: () => void;
@@ -12,6 +11,7 @@ interface ProfileSetupProps {
 const ProfileSetup: React.FC<ProfileSetupProps> = ({ onNext }) => {
   const {
     nickname,
+    nicknameInputError,
     isNicknameChecked,
     isNicknameValid,
     intro,
@@ -24,7 +24,6 @@ const ProfileSetup: React.FC<ProfileSetupProps> = ({ onNext }) => {
     handleCheckDuplicate,
     validate,
   } = useProfileSetup();
-  const { showToast } = useSignup();
   const nicknameRef = React.useRef<HTMLDivElement>(null);
 
   const nameRef = React.useRef<HTMLDivElement>(null);
@@ -62,36 +61,43 @@ const ProfileSetup: React.FC<ProfileSetupProps> = ({ onNext }) => {
               <span className="text-primary-1 font-sans text-[14px] font-semibold leading-[145%] tracking-[-0.014px] t:text-[20px] t:leading-[135%] t:tracking-[-0.02px]">
                 닉네임
               </span>
-              <div className="flex flex-row items-center justify-between w-full gap-[8px]">
-                <div className="w-[158px] t:flex-1">
-                  {/* Mobile Input */}
-                  <div className="block w-full t:hidden">
-                    <JoinInput
-                      value={nickname}
-                      onChange={handleNicknameChange}
-                      placeholder="(최대 20자)"
-                      className="h-[36px] py-0 border-Subbrown-4 placeholder-Gray-3 text-[14px] font-normal w-full bg-white"
-                    />
+              <div className="flex flex-col w-full gap-[4px]">
+                <div className="flex flex-row items-center justify-between w-full gap-[8px]">
+                  <div className="w-[158px] t:flex-1">
+                    {/* Mobile Input */}
+                    <div className="block w-full t:hidden">
+                      <JoinInput
+                        value={nickname}
+                        onChange={handleNicknameChange}
+                        placeholder="(최대 20자)"
+                        className="h-[36px] py-0 border-Subbrown-4 placeholder-Gray-3 text-[14px] font-normal w-full bg-white"
+                      />
+                    </div>
+                    {/* Desktop Input */}
+                    <div className="hidden w-full t:block">
+                      <JoinInput
+                        value={nickname}
+                        onChange={handleNicknameChange}
+                        placeholder="닉네임을 입력해주세요(최대 20글자)"
+                        className="h-[44px] border-Subbrown-4 placeholder-Gray-3 text-[14px] font-normal w-full bg-white"
+                      />
+                    </div>
                   </div>
-                  {/* Desktop Input */}
-                  <div className="hidden w-full t:block">
-                    <JoinInput
-                      value={nickname}
-                      onChange={handleNicknameChange}
-                      placeholder="닉네임을 입력해주세요(최대 20글자)"
-                      className="h-[44px] border-Subbrown-4 placeholder-Gray-3 text-[14px] font-normal w-full bg-white"
-                    />
-                  </div>
+                  <JoinButton
+                    onClick={handleCheckDuplicate}
+                    disabled={!isNicknameValid || isNicknameChecked}
+                    variant={isNicknameValid ? "primary" : "secondary"}
+                    className={`w-[106px] h-[36px] t:h-[44px] px-0 py-0 text-[14px] shrink-0 ${isNicknameChecked ? "font-medium" : "font-normal"
+                      }`}
+                  >
+                    {isNicknameChecked ? "확인됨" : "중복확인"}
+                  </JoinButton>
                 </div>
-                <JoinButton
-                  onClick={handleCheckDuplicate}
-                  disabled={!isNicknameValid || isNicknameChecked}
-                  variant={isNicknameValid ? "primary" : "secondary"}
-                  className={`w-[106px] h-[36px] t:h-[44px] px-0 py-0 text-[14px] shrink-0 ${isNicknameChecked ? "font-medium" : "font-normal"
-                    }`}
-                >
-                  {isNicknameChecked ? "확인됨" : "중복확인"}
-                </JoinButton>
+                {nicknameInputError && (
+                  <p className="w-full text-[12px] text-Red text-left">
+                    {nicknameInputError}
+                  </p>
+                )}
               </div>
             </div>
             {/* 한줄소개 */}

--- a/src/components/base-ui/Join/steps/ProfileSetup/useProfileSetup.ts
+++ b/src/components/base-ui/Join/steps/ProfileSetup/useProfileSetup.ts
@@ -1,5 +1,6 @@
 import { useSignup } from "@/contexts/SignupContext";
 import { authService } from "@/services/authService";
+import { useState } from "react";
 import { z } from "zod";
 
 const profileSchema = z.object({
@@ -13,6 +14,7 @@ const profileSchema = z.object({
 });
 
 export const useProfileSetup = () => {
+  const [nicknameInputError, setNicknameInputError] = useState("");
   const {
     nickname,
     setNickname,
@@ -30,9 +32,13 @@ export const useProfileSetup = () => {
   const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     // 닉네임 : 영어 소문자 및 특수문자, 숫자만 사용 가능, 최대 20글자
-    const filteredValue = value.replace(/[^a-z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/g, "").slice(0, 20);
+    const allowedValue = value.replace(/[^a-z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/g, "");
+    const filteredValue = allowedValue.slice(0, 20);
+    setNicknameInputError(value !== allowedValue ? "한글과 띄어쓰기는 사용할 수 없습니다." : "");
     setNickname(filteredValue);
-    setIsNicknameChecked(false);
+    if (filteredValue !== nickname) {
+      setIsNicknameChecked(false);
+    }
   };
 
   const handleIntroChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -70,8 +76,8 @@ export const useProfileSetup = () => {
         showToast("이미 사용 중인 닉네임입니다.");
         setIsNicknameChecked(false);
       }
-    } catch (error: any) {
-      showToast(error.message || "닉네임 확인 중 오류가 발생했습니다.");
+    } catch (error: unknown) {
+      showToast(error instanceof Error ? error.message : "닉네임 확인 중 오류가 발생했습니다.");
     }
   };
 
@@ -97,6 +103,7 @@ export const useProfileSetup = () => {
 
   return {
     nickname,
+    nicknameInputError,
     isNicknameChecked,
     isNicknameValid,
     intro,
@@ -110,4 +117,3 @@ export const useProfileSetup = () => {
     validate,
   };
 };
-

--- a/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
+++ b/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
@@ -12,7 +12,7 @@ import ActionSelectionModal from "@/components/common/modals/report-block/Action
 import BlockConfirmModal from "@/components/common/modals/report-block/BlockConfirmModal";
 import { useReportBlockFlow } from "@/hooks/useReportBlockFlow";
 import { ReportReason } from "@/types/report";
-import { getErrorMessage } from "@/lib/api/errors";
+import { getProfileAccessErrorMessage } from "@/utils/profileAccess";
 
 // [보조 컴포넌트] 액션 버튼 (구독하기 / 신고하기)
 function ActionButton({
@@ -98,12 +98,7 @@ export default function ProfileUserInfo({ nickname }: { nickname: string }) {
   }
 
   if (isError || !profile) {
-    // TODO: PM 요청 시 차단 상태별 메시지 수정 필요 (BLOCK_404: 내가 차단, BLOCK_405: 상대가 차단)
-    const apiError = error as { code?: string } | null;
-    const message =
-      (apiError?.code === "BLOCK_404" || apiError?.code === "BLOCK_405")
-        ? getErrorMessage(apiError.code)
-        : "프로필 정보를 불러올 수 없습니다.";
+    const message = getProfileAccessErrorMessage(error) ?? "프로필 정보를 불러올 수 없습니다.";
     return (
       <div className="flex justify-center items-center py-10 text-Gray-5 body_1 min-h-[200px]">
         {message}

--- a/src/components/base-ui/Settings/SettingsDetailLayout.tsx
+++ b/src/components/base-ui/Settings/SettingsDetailLayout.tsx
@@ -21,7 +21,7 @@ export default function SettingsDetailLayout({
   const containerXlStyle =
     mode === "narrow"
       ? "xl:w-[1152px] xl:pl-[68px] xl:pr-[400px]" // 우측 여백이 많은 폼 형태
-      : "xl:w-[1152px] xl:px-[76px]"; // 좌우 균형이 맞는 와이드 형태
+      : "xl:w-[1152px] xl:pl-[68px] xl:pr-[76px]"; // 좌측 기준선은 narrow와 통일
 
   const contentXlStyle =
     mode === "narrow"

--- a/src/components/base-ui/Settings/SettingsSidebar.tsx
+++ b/src/components/base-ui/Settings/SettingsSidebar.tsx
@@ -45,9 +45,9 @@ export default function SettingsSidebar() {
 
             {/* 세부 메뉴 리스트 */}
             <div className="flex flex-col items-start gap-[2px] self-stretch">
-              {group.items.map((item: any) => {
-                const isExternal = !!item.isExternal;
-                const href = isExternal ? EXTERNAL_LINKS.INQUIRY_FORM_URL : item.href;
+              {group.items.map((item) => {
+                const isExternal = "isExternal" in item && item.isExternal;
+                const href = isExternal ? EXTERNAL_LINKS.SUPPORT_URL : item.href;
 
                 return (
                   <SettingsMenuItem

--- a/src/components/base-ui/home/Club/HomeClubSection.tsx
+++ b/src/components/base-ui/home/Club/HomeClubSection.tsx
@@ -47,7 +47,7 @@ export default function HomeClubSection({ groups, isLoading }: HomeClubSectionPr
         type="button"
         onClick={handleSearchGroup}
         className="w-full h-[32px] t:h-[48px] py-3 rounded-[8px] bg-white border border-[#E6E6E6]
-                  text-[13px] flex items-center justify-center gap-2 cursor-pointer"
+                  text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-98 hover:-translate-y-[1px]"
       >
         <Image
           src="/search.svg"
@@ -63,7 +63,7 @@ export default function HomeClubSection({ groups, isLoading }: HomeClubSectionPr
         type="button"
         onClick={handleCreateGroup}
         className="w-full h-[32px] t:h-[48px] py-3 rounded-[6px] bg-primary-3 text-white
-                  text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-90"
+                  text-[13px] flex items-center justify-center gap-2 cursor-pointer transition-all hover:brightness-90 hover:-translate-y-[1px]"
       >
         <Image
           src="/icon_plus.svg"

--- a/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_element.tsx
@@ -56,7 +56,7 @@ export default function ListSubscribeElement({
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
-          className={`hidden t:flex px-[10px] t:px-[17px] py-[6px] t:py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[11px] t:text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors ${isFollowing
+          className={`hidden t:flex px-[10px] t:px-[17px] py-[6px] t:py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[11px] t:text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors cursor-pointer ${isFollowing
             ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
             : "bg-primary-2 text-white hover:bg-primary-1"
             }`}
@@ -67,7 +67,7 @@ export default function ListSubscribeElement({
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
-          className={`flex t:hidden w-full px-[17px] py-[6px] justify-center items-center rounded-[10px] text-[11px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap transition-colors ${isFollowing
+          className={`flex t:hidden w-full px-[17px] py-[6px] justify-center items-center rounded-[10px] text-[11px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap transition-colors cursor-pointer ${isFollowing
             ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
             : "bg-primary-2 text-white hover:bg-primary-1"
             }`}

--- a/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
@@ -56,7 +56,7 @@ function ListSubscribeElementLarge({
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onSubscribeClick?.(); }}
-          className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors ${isFollowing
+          className={`flex px-[17px] py-[8px] justify-center items-center gap-[10px] rounded-[8px] text-[12px] font-semibold leading-[100%] tracking-[-0.012px] whitespace-nowrap shrink-0 transition-colors cursor-pointer ${isFollowing
             ? "bg-Subbrown-4 text-primary-3 hover:bg-Subbrown-3"
             : "bg-primary-2 text-white hover:bg-primary-1"
             }`}

--- a/src/components/common/MobileBackButton.tsx
+++ b/src/components/common/MobileBackButton.tsx
@@ -1,0 +1,32 @@
+type MobileBackButtonProps = {
+  label?: string;
+  onClick: () => void;
+  className?: string;
+};
+
+export default function MobileBackButton({
+  label = "뒤로가기",
+  onClick,
+  className = "",
+}: MobileBackButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`t:hidden w-full flex items-center gap-2 px-[10px] py-[12px] border-b border-Gray-2 text-Gray-7 body_1_2 ${className}`}
+    >
+      <svg
+        width="9"
+        height="11"
+        viewBox="0 0 9 11"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        className="shrink-0"
+      >
+        <path d="M0 5.19629L9 10.3924V0.00014L0 5.19629Z" fill="#BBAA9B" />
+      </svg>
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/src/components/common/MobileBackButton.tsx
+++ b/src/components/common/MobileBackButton.tsx
@@ -13,7 +13,7 @@ export default function MobileBackButton({
     <button
       type="button"
       onClick={onClick}
-      className={`t:hidden w-full flex items-center gap-2 px-[10px] py-[12px] border-b border-Gray-2 text-Gray-7 body_1_2 ${className}`}
+      className={`t:hidden w-full cursor-pointer flex items-center gap-2 px-[10px] py-[12px] border-b border-Gray-2 text-Gray-7 body_1_2 transition-colors hover:bg-Gray-1 ${className}`}
     >
       <svg
         width="9"

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -1,4 +1,5 @@
 export const EXTERNAL_LINKS = {
+    SUPPORT_URL: "https://www.checkmo.co.kr/support",
     INQUIRY_FORM_URL: "https://docs.google.com/forms/d/e/1FAIpQLSfcY9nWElffO0gbjRlxFzEV4YKCOznMsv4PqfFO8MjgR1xaBg/viewform",
     ALADIN_BESTSELLER_URL: "https://www.aladin.co.kr/shop/common/wbest.aspx?BranchType=1&srsltid=AfmBOoormYbm3TGHXQJYOcGgci2IQp6ytpjw-CJgV2wQALS9lsE5-pTo",
     NEWS_FROM_URL: "https://forms.gle/7ZBdXSn9BnR7MC6N6",

--- a/src/contexts/SignupContext.tsx
+++ b/src/contexts/SignupContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useState, ReactNode, useCallback, useRef, useMemo } from "react";
+import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
 
 interface SignupState {
     // Terms
@@ -71,7 +72,7 @@ const initialState: SignupState = {
     name: "",
     phone: "",
     isNicknameChecked: false,
-    profileImage: "/default_profile_1.svg",
+    profileImage: DEFAULT_PROFILE_IMAGE,
     isProfileImageSet: false,
     selectedInterests: [],
     isSocial: false,

--- a/src/lib/api/errors/errorMapper.ts
+++ b/src/lib/api/errors/errorMapper.ts
@@ -14,6 +14,7 @@ export const ERROR_MESSAGES: Record<string, string> = {
     EXPIRED_TOKEN: "만료된 토큰입니다.",
 
     // Block Errors
+    MEMBER_400: "해당 회원을 찾을 수 없습니다.",
     BLOCK_404: "차단한 사용자입니다.",
     BLOCK_405: "조회가 불가능한 프로필입니다.",
 };

--- a/src/utils/profileAccess.ts
+++ b/src/utils/profileAccess.ts
@@ -1,0 +1,15 @@
+import { getErrorMessage, hasErrorCode } from "@/lib/api/errors";
+
+const PROFILE_ACCESS_ERROR_CODES = new Set(["MEMBER_400", "BLOCK_404", "BLOCK_405"]);
+
+export function getProfileAccessErrorMessage(error: unknown): string | null {
+  if (!hasErrorCode(error) || !PROFILE_ACCESS_ERROR_CODES.has(error.code)) {
+    return null;
+  }
+
+  if (error.code === "MEMBER_400") {
+    return "탈퇴했거나 존재하지 않는 회원입니다.";
+  }
+
+  return error.message || getErrorMessage(error.code);
+}

--- a/src/utils/profileImage.ts
+++ b/src/utils/profileImage.ts
@@ -15,8 +15,8 @@ export function getProfileImageSrc(src?: string | null): string {
     return `https:${trimmed}`;
   }
 
-  if (isValidUrl(trimmed)) {
-    return trimmed;
+  if (isValidUrl(src)) {
+    return src.trim();
   }
 
   if (LOCAL_IMAGE_FILE_PATTERN.test(trimmed)) {

--- a/src/utils/profileImage.ts
+++ b/src/utils/profileImage.ts
@@ -1,0 +1,27 @@
+import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { isValidUrl } from "@/utils/url";
+
+const LOCAL_IMAGE_FILE_PATTERN =
+  /^[A-Za-z0-9._/-]+\.(?:svg|png|jpe?g|webp|gif|avif)$/;
+
+export function getProfileImageSrc(src?: string | null): string {
+  const trimmed = typeof src === "string" ? src.trim() : "";
+
+  if (!trimmed || trimmed === "string") {
+    return DEFAULT_PROFILE_IMAGE;
+  }
+
+  if (trimmed.startsWith("//")) {
+    return `https:${trimmed}`;
+  }
+
+  if (isValidUrl(trimmed)) {
+    return trimmed;
+  }
+
+  if (LOCAL_IMAGE_FILE_PATTERN.test(trimmed)) {
+    return `/${trimmed.replace(/^\.?\//, "")}`;
+  }
+
+  return DEFAULT_PROFILE_IMAGE;
+}


### PR DESCRIPTION
## 작업 내용

QA 이슈 대응으로 프로필 이미지, 접근 불가 프로필, 모바일/반응형 UI, 버튼 hover/cursor, 설정 링크/정렬 등을 전반적으로 보정했습니다.

## 주요 변경 사항

### 프로필/기본 이미지 처리
- 기본 프로필 이미지가 깨지는 케이스를 공통 유틸 `getProfileImageSrc`로 보정
- 책장, 모임 팀원, 토론, 리뷰, 채팅, 그룹핑 등 프로필 이미지 노출 영역에 fallback 적용
- `profileImageUrl: null` 타입 케이스로 발생하던 빌드 오류 수정
- 프로필 생성/모임 생성에서 기본 프로필 선택 상태와 이미지 표시 UX 개선

### 접근 불가 프로필 처리
- 탈퇴/존재하지 않는 회원, 차단 관계 등으로 다른 사람 프로필 조회가 불가능한 경우 안내 문구 추가
- 프로필 조회 실패 시 책 이야기/서재/모임 탭 데이터를 계속 불러오지 않도록 처리
- `MEMBER_400`, `BLOCK_404`, `BLOCK_405` 에러 메시지 매핑 보정

### 책이야기 UX
- 책이야기 카드 댓글 버튼 hover 효과를 좋아요 버튼과 동일한 느낌으로 보정
- 댓글 클릭 시 상세 페이지의 댓글 영역(`#comments`)으로 이동 및 댓글 입력창 포커싱
- 책이야기/추천 사용자 구독 버튼에 cursor pointer 적용

### 모임/공지/책장 UI
- 홈 > 모임 CTA 카드 hover 시 살짝 위로 올라가는 효과 추가
- 모임 생성 화면 내 활성 버튼들에 cursor pointer 적용
- 모임 생성 이미지 업로드 상태를 `업로드 중...` / 실패 문구로 분리
- 공지사항 생성 화면의 버튼/토글/날짜/이미지 액션 cursor pointer 보정
- 공지사항 생성 > 책장 등록 모달의 모바일 뒤로가기 깨짐 수정
- 반응형 책장 등록/공지 등록/신청자 관리 등 모바일 뒤로가기 버튼을 공통 컴포넌트로 통일

### 설정
- 고객센터/문의하기 링크를 `https://www.checkmo.co.kr/support`로 변경
- 설정 상세 페이지 제목 좌측 정렬 기준을 `narrow` / `wide` 모드 간 통일
- 소셜 로그인/탈퇴 페이지 내부 제목 정렬 보정
- 버전 업데이트 날짜를 `2026.07.08`로 변경

## 검증

- 변경 파일 대상 ESLint 통과
- 깨진 모바일 뒤로가기 이미지 참조 검색 확인
- 관련 UI 경로에서 cursor/hover 적용 파일 단위 확인

## 참고

- 전체 레포 lint/build는 기존 전역 lint 이슈가 있어 변경 파일 단위로 검증했습니다.