### PR TITLE
feat: add ios app open cta for story detail

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,18 @@ const nextConfig: NextConfig = {
       { source: "/marketing-consent", destination: "/support/v1/marketing-consent", permanent: true },
     ];
   },
+  async headers() {
+    return [
+      {
+        source: "/.well-known/apple-app-site-association",
+        headers: [{ key: "Content-Type", value: "application/json" }],
+      },
+      {
+        source: "/apple-app-site-association",
+        headers: [{ key: "Content-Type", value: "application/json" }],
+      },
+    ];
+  },
 };
 
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ import { withSentryConfig } from "@sentry/nextjs";
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
+  turbopack: {
+    root: process.cwd(),
+  },
   images: {
     remotePatterns: [
       {
@@ -40,4 +43,3 @@ export default withSentryConfig(nextConfig, {
     disable: false,
   },
 });
-

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,19 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "737FQ6NT2H.kr.co.checkmo.app",
+        "paths": [
+          "/stories/*",
+          "/book-stories/*",
+          "/groups/*",
+          "/clubs/*",
+          "/news/*",
+          "/members/*",
+          "/profile/*"
+        ]
+      }
+    ]
+  }
+}

--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -1,0 +1,19 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "737FQ6NT2H.kr.co.checkmo.app",
+        "paths": [
+          "/stories/*",
+          "/book-stories/*",
+          "/groups/*",
+          "/clubs/*",
+          "/news/*",
+          "/members/*",
+          "/profile/*"
+        ]
+      }
+    ]
+  }
+}

--- a/src/app/(main)/stories/[id]/StoryDetailClient.tsx
+++ b/src/app/(main)/stories/[id]/StoryDetailClient.tsx
@@ -109,7 +109,7 @@ export default function StoryDetailClient() {
         </div>
         <div className="d:subhead_4_1 text-Gray-7">상세보기</div>
       </div>
-      <AppOpenCta appPath={`/stories/${story.bookStoryId}`} className="mt-4" />
+      <AppOpenCta appPath={`/stories/${story.bookStoryId}`} />
       <div>
         <StoryNavigation currentId={story.bookStoryId} prevId={prevId} nextId={nextId}>
           <BookstoryDetail

--- a/src/app/(main)/stories/[id]/StoryDetailClient.tsx
+++ b/src/app/(main)/stories/[id]/StoryDetailClient.tsx
@@ -4,6 +4,7 @@ import BookstoryDetail from "@/components/base-ui/BookStory/Detatil/bookstory_de
 import StoryNavigation from "@/components/base-ui/BookStory/Detatil/story_navigation";
 import CommentSection from "@/components/base-ui/Comment/comment_section_bookcase";
 import BookshelfDeleteConfirmModal from "@/components/base-ui/Bookcase/bookid/BookshelfDeleteConfirmModal";
+import AppOpenCta from "@/components/common/AppOpenCta";
 
 import { useState } from "react";
 import Image from "next/image";
@@ -29,6 +30,14 @@ export default function StoryDetailClient() {
   const id = params?.id as string;
   const storyId = Number(id);
 
+  const { data: story, isLoading, isError, error } = useStoryDetailQuery(storyId);
+  const { mutate: toggleLike } = useToggleStoryLikeMutation();
+  const { mutate: deleteStory, isPending: isDeletePending } = useDeleteBookStoryMutation();
+  const { mutate: toggleFollow } = useToggleFollowMutation();
+  const { isLoggedIn, openLoginModal } = useAuthStore();
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
   if (!id || isNaN(storyId)) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[400px]">
@@ -37,14 +46,6 @@ export default function StoryDetailClient() {
       </div>
     );
   }
-
-  const { data: story, isLoading, isError, error } = useStoryDetailQuery(storyId);
-  const { mutate: toggleLike } = useToggleStoryLikeMutation();
-  const { mutate: deleteStory, isPending: isDeletePending } = useDeleteBookStoryMutation();
-  const { mutate: toggleFollow } = useToggleFollowMutation();
-  const { isLoggedIn, openLoginModal } = useAuthStore();
-
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const handleToggleLike = () => {
     if (!isLoggedIn) {
@@ -108,6 +109,7 @@ export default function StoryDetailClient() {
         </div>
         <div className="d:subhead_4_1 text-Gray-7">상세보기</div>
       </div>
+      <AppOpenCta appPath={`/stories/${story.bookStoryId}`} className="mt-4" />
       <div>
         <StoryNavigation currentId={story.bookStoryId} prevId={prevId} nextId={nextId}>
           <BookstoryDetail

--- a/src/app/(main)/stories/[id]/page.tsx
+++ b/src/app/(main)/stories/[id]/page.tsx
@@ -1,19 +1,33 @@
 import type { Metadata } from "next";
+import { buildCheckmoWebUrl, CHECKMO_APP_LINKS } from "@/constants/links";
 import StoryDetailClient from "./StoryDetailClient";
 
 type Props = { params: Promise<{ id: string }> };
 
+function getAppleSmartAppBannerMetadata(id: string): Metadata {
+  const appArgument = buildCheckmoWebUrl(`/stories/${id}`);
+
+  return {
+    other: {
+      "apple-itunes-app": `app-id=${CHECKMO_APP_LINKS.IOS_APP_STORE_ID}, app-argument=${appArgument}`,
+    },
+  };
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
+  const appBannerMetadata = getAppleSmartAppBannerMetadata(id);
+
   try {
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/book-stories/${id}`, {
       next: { revalidate: 3600 },
     });
-    if (!res.ok) return { title: "책이야기" };
+    if (!res.ok) return { title: "책이야기", ...appBannerMetadata };
     const data = await res.json();
-    if (!data?.result) return { title: "책이야기" };
+    if (!data?.result) return { title: "책이야기", ...appBannerMetadata };
     const story = data.result;
     return {
+      ...appBannerMetadata,
       title: story.bookStoryTitle,
       description: story.description?.slice(0, 100),
       openGraph: {
@@ -23,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       },
     };
   } catch {
-    return { title: "책이야기" };
+    return { title: "책이야기", ...appBannerMetadata };
   }
 }
 

--- a/src/components/common/AppOpenCta.tsx
+++ b/src/components/common/AppOpenCta.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import appIcon from "@/app/apple-icon.png";
 import { buildCheckmoAppUrl, CHECKMO_APP_LINKS } from "@/constants/links";
 
 const APP_OPEN_CTA_DISMISSED_KEY = "checkmo.appOpenCta.dismissed";
+const DISMISS_ANIMATION_MS = 180;
 
 type AppOpenCtaProps = {
   appPath: string;
@@ -22,12 +25,21 @@ function isIOSDevice() {
 
 export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const openAttemptCleanupRef = useRef<(() => void) | null>(null);
+  const dismissTimeoutRef = useRef<number | null>(null);
   const appUrl = useMemo(() => buildCheckmoAppUrl(appPath), [appPath]);
 
   const cleanupOpenAttempt = useCallback(() => {
     openAttemptCleanupRef.current?.();
     openAttemptCleanupRef.current = null;
+  }, []);
+
+  const cleanupDismissTimeout = useCallback(() => {
+    if (dismissTimeoutRef.current !== null) {
+      window.clearTimeout(dismissTimeoutRef.current);
+      dismissTimeoutRef.current = null;
+    }
   }, []);
 
   useEffect(() => {
@@ -40,19 +52,22 @@ export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps)
         isDismissed = false;
       }
 
-      setIsVisible(isIOSDevice() && !isDismissed);
+      const shouldShow = isIOSDevice() && !isDismissed;
+      setIsVisible(shouldShow);
+      setIsClosing(false);
     });
 
     return () => window.cancelAnimationFrame(frame);
   }, []);
 
   useEffect(() => cleanupOpenAttempt, [cleanupOpenAttempt]);
+  useEffect(() => cleanupDismissTimeout, [cleanupDismissTimeout]);
 
   const handleOpenApp = useCallback(() => {
     cleanupOpenAttempt();
 
     let didLeavePage = false;
-    let timeoutId: ReturnType<typeof window.setTimeout> | null = null;
+    let timeoutId: number | null = null;
 
     const markPageLeave = () => {
       didLeavePage = true;
@@ -84,6 +99,7 @@ export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps)
 
   const handleDismiss = useCallback(() => {
     cleanupOpenAttempt();
+    cleanupDismissTimeout();
 
     try {
       window.localStorage.setItem(APP_OPEN_CTA_DISMISSED_KEY, "true");
@@ -91,38 +107,58 @@ export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps)
       // localStorage 접근이 막혀도 현재 화면에서는 즉시 숨긴다.
     }
 
-    setIsVisible(false);
-  }, [cleanupOpenAttempt]);
+    setIsClosing(true);
+    dismissTimeoutRef.current = window.setTimeout(() => {
+      setIsVisible(false);
+      dismissTimeoutRef.current = null;
+    }, DISMISS_ANIMATION_MS);
+  }, [cleanupDismissTimeout, cleanupOpenAttempt]);
 
   if (!isVisible) return null;
 
   return (
-    <section className={`t:hidden ${className}`} aria-label="책모 앱에서 보기">
-      <div className="group flex items-center justify-between gap-3 rounded-[8px] border border-Subbrown-4 bg-White px-4 py-3 shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:border-Subbrown-3 hover:shadow-md">
-        <div className="min-w-0 flex-1">
-          <p className="body_2_1 text-primary-2">책모 앱</p>
-          <p className="body_1_1 text-Gray-7">앱에서 바로 보기</p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <button
-            type="button"
-            onClick={handleOpenApp}
-            className="inline-flex h-10 min-w-[88px] items-center justify-center rounded-[8px] bg-primary-1 px-4 text-White body_1_1 transition-colors duration-200 hover:bg-primary-3 active:scale-[0.98]"
-            aria-label="책모 앱 열기"
-          >
-            앱 열기
-          </button>
-          <button
-            type="button"
-            onClick={handleDismiss}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-Gray-4 transition-colors duration-200 hover:bg-Subbrown-4 hover:text-Gray-7 active:scale-[0.96]"
-            aria-label="책모 앱 열기 안내 닫기"
-          >
-            <span aria-hidden="true" className="text-[20px] leading-none">
-              ×
-            </span>
-          </button>
-        </div>
+    <section
+      className={`fixed z-40 t:hidden ${className}`}
+      style={{
+        left: 16,
+        width: "calc(100vw - 32px)",
+        bottom: "calc(env(safe-area-inset-bottom) + 82px)",
+      }}
+      aria-label="책모 앱에서 보기"
+    >
+      <div
+        className={`group grid h-16 w-full items-center gap-2 overflow-hidden rounded-[8px] border border-Subbrown-4 bg-White px-3 shadow-sm transition-[border-color,box-shadow,opacity,transform] duration-200 ease-out hover:-translate-y-0.5 hover:border-Subbrown-3 hover:shadow-md ${
+          isClosing ? "pointer-events-none translate-y-2 scale-[0.98] opacity-0" : "opacity-100"
+        }`}
+        style={{ gridTemplateColumns: "36px minmax(0, 1fr) 72px 28px" }}
+      >
+        <Image
+          src={appIcon}
+          alt="책모"
+          width={36}
+          height={36}
+          className="rounded-[8px]"
+          priority={false}
+        />
+        <p className="body_1_1 min-w-0 truncate text-Gray-7">앱에서 바로 보기</p>
+        <button
+          type="button"
+          onClick={handleOpenApp}
+          className="inline-flex h-10 w-full items-center justify-center rounded-[8px] bg-primary-1 text-White body_1_1 transition-colors duration-200 hover:bg-primary-3 active:scale-[0.98]"
+          aria-label="책모 앱 열기"
+        >
+          앱 열기
+        </button>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-Gray-4 transition-colors duration-200 hover:bg-Subbrown-4 hover:text-Gray-7 active:scale-[0.96]"
+          aria-label="책모 앱 열기 안내 닫기"
+        >
+          <span aria-hidden="true" className="text-[20px] leading-none">
+            ×
+          </span>
+        </button>
       </div>
     </section>
   );

--- a/src/components/common/AppOpenCta.tsx
+++ b/src/components/common/AppOpenCta.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Image from "next/image";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { buildCheckmoAppUrl, CHECKMO_APP_LINKS } from "@/constants/links";
+
+type AppOpenCtaProps = {
+  appPath: string;
+  className?: string;
+};
+
+function isIOSDevice() {
+  if (typeof window === "undefined") return false;
+
+  const userAgent = window.navigator.userAgent;
+  const platform = window.navigator.platform;
+  const isIPadOS = platform === "MacIntel" && window.navigator.maxTouchPoints > 1;
+
+  return (/iPad|iPhone|iPod/.test(userAgent) || isIPadOS) && !/Android/i.test(userAgent);
+}
+
+export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const appUrl = useMemo(() => buildCheckmoAppUrl(appPath), [appPath]);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      setIsVisible(isIOSDevice());
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, []);
+
+  const handleOpenApp = useCallback(() => {
+    let didLeavePage = false;
+
+    const markPageLeave = () => {
+      didLeavePage = true;
+    };
+
+    document.addEventListener("visibilitychange", markPageLeave, { once: true });
+    window.addEventListener("pagehide", markPageLeave, { once: true });
+    window.location.href = appUrl;
+
+    window.setTimeout(() => {
+      document.removeEventListener("visibilitychange", markPageLeave);
+      window.removeEventListener("pagehide", markPageLeave);
+
+      if (!didLeavePage && document.visibilityState === "visible") {
+        window.location.href = CHECKMO_APP_LINKS.IOS_APP_STORE_URL;
+      }
+    }, 1600);
+  }, [appUrl]);
+
+  if (!isVisible) return null;
+
+  return (
+    <section className={`t:hidden ${className}`} aria-label="책모 앱에서 보기">
+      <div className="flex items-center justify-between gap-3 rounded-[8px] border border-Subbrown-4 bg-White px-4 py-3 shadow-sm">
+        <div className="min-w-0">
+          <p className="body_2_1 text-primary-2">책모 앱</p>
+          <p className="body_1_1 text-Gray-7">앱에서 바로 보기</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleOpenApp}
+          className="shrink-0 inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-primary-1 px-4 text-White body_1_1 active:scale-[0.98]"
+          aria-label="책모 앱 열기"
+        >
+          앱 열기
+          <Image src="/ArrowRight.svg" alt="" width={14} height={14} className="brightness-0 invert" />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/common/AppOpenCta.tsx
+++ b/src/components/common/AppOpenCta.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import Image from "next/image";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildCheckmoAppUrl, CHECKMO_APP_LINKS } from "@/constants/links";
+
+const APP_OPEN_CTA_DISMISSED_KEY = "checkmo.appOpenCta.dismissed";
 
 type AppOpenCtaProps = {
   appPath: string;
@@ -21,55 +22,107 @@ function isIOSDevice() {
 
 export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const openAttemptCleanupRef = useRef<(() => void) | null>(null);
   const appUrl = useMemo(() => buildCheckmoAppUrl(appPath), [appPath]);
+
+  const cleanupOpenAttempt = useCallback(() => {
+    openAttemptCleanupRef.current?.();
+    openAttemptCleanupRef.current = null;
+  }, []);
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
-      setIsVisible(isIOSDevice());
+      let isDismissed = false;
+
+      try {
+        isDismissed = window.localStorage.getItem(APP_OPEN_CTA_DISMISSED_KEY) === "true";
+      } catch {
+        isDismissed = false;
+      }
+
+      setIsVisible(isIOSDevice() && !isDismissed);
     });
 
     return () => window.cancelAnimationFrame(frame);
   }, []);
 
+  useEffect(() => cleanupOpenAttempt, [cleanupOpenAttempt]);
+
   const handleOpenApp = useCallback(() => {
+    cleanupOpenAttempt();
+
     let didLeavePage = false;
+    let timeoutId: ReturnType<typeof window.setTimeout> | null = null;
 
     const markPageLeave = () => {
       didLeavePage = true;
     };
 
+    const cleanup = () => {
+      document.removeEventListener("visibilitychange", markPageLeave);
+      window.removeEventListener("pagehide", markPageLeave);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+      openAttemptCleanupRef.current = null;
+    };
+
+    openAttemptCleanupRef.current = cleanup;
+
     document.addEventListener("visibilitychange", markPageLeave, { once: true });
     window.addEventListener("pagehide", markPageLeave, { once: true });
     window.location.href = appUrl;
 
-    window.setTimeout(() => {
-      document.removeEventListener("visibilitychange", markPageLeave);
-      window.removeEventListener("pagehide", markPageLeave);
+    timeoutId = window.setTimeout(() => {
+      cleanup();
 
       if (!didLeavePage && document.visibilityState === "visible") {
         window.location.href = CHECKMO_APP_LINKS.IOS_APP_STORE_URL;
       }
     }, 1600);
-  }, [appUrl]);
+  }, [appUrl, cleanupOpenAttempt]);
+
+  const handleDismiss = useCallback(() => {
+    cleanupOpenAttempt();
+
+    try {
+      window.localStorage.setItem(APP_OPEN_CTA_DISMISSED_KEY, "true");
+    } catch {
+      // localStorage 접근이 막혀도 현재 화면에서는 즉시 숨긴다.
+    }
+
+    setIsVisible(false);
+  }, [cleanupOpenAttempt]);
 
   if (!isVisible) return null;
 
   return (
     <section className={`t:hidden ${className}`} aria-label="책모 앱에서 보기">
-      <div className="flex items-center justify-between gap-3 rounded-[8px] border border-Subbrown-4 bg-White px-4 py-3 shadow-sm">
-        <div className="min-w-0">
+      <div className="group flex items-center justify-between gap-3 rounded-[8px] border border-Subbrown-4 bg-White px-4 py-3 shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:border-Subbrown-3 hover:shadow-md">
+        <div className="min-w-0 flex-1">
           <p className="body_2_1 text-primary-2">책모 앱</p>
           <p className="body_1_1 text-Gray-7">앱에서 바로 보기</p>
         </div>
-        <button
-          type="button"
-          onClick={handleOpenApp}
-          className="shrink-0 inline-flex h-10 items-center gap-1.5 rounded-[8px] bg-primary-1 px-4 text-White body_1_1 active:scale-[0.98]"
-          aria-label="책모 앱 열기"
-        >
-          앱 열기
-          <Image src="/ArrowRight.svg" alt="" width={14} height={14} className="brightness-0 invert" />
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={handleOpenApp}
+            className="inline-flex h-10 min-w-[88px] items-center justify-center rounded-[8px] bg-primary-1 px-4 text-White body_1_1 transition-colors duration-200 hover:bg-primary-3 active:scale-[0.98]"
+            aria-label="책모 앱 열기"
+          >
+            앱 열기
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-Gray-4 transition-colors duration-200 hover:bg-Subbrown-4 hover:text-Gray-7 active:scale-[0.96]"
+            aria-label="책모 앱 열기 안내 닫기"
+          >
+            <span aria-hidden="true" className="text-[20px] leading-none">
+              ×
+            </span>
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/src/components/common/AppOpenCta.tsx
+++ b/src/components/common/AppOpenCta.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import appIcon from "@/app/apple-icon.png";
 import { buildCheckmoAppUrl, CHECKMO_APP_LINKS } from "@/constants/links";
 
-const APP_OPEN_CTA_DISMISSED_KEY = "checkmo.appOpenCta.dismissed";
+const APP_OPEN_CTA_SESSION_DISMISSED_KEY = "checkmo.appOpenCta.sessionDismissed";
 const DISMISS_ANIMATION_MS = 180;
 
 type AppOpenCtaProps = {
@@ -21,6 +21,14 @@ function isIOSDevice() {
   const isIPadOS = platform === "MacIntel" && window.navigator.maxTouchPoints > 1;
 
   return (/iPad|iPhone|iPod/.test(userAgent) || isIPadOS) && !/Android/i.test(userAgent);
+}
+
+function shouldForceShowCta() {
+  return new URLSearchParams(window.location.search).get("showCta") === "1";
+}
+
+function isAppOpenCtaDismissedInSession() {
+  return window.sessionStorage.getItem(APP_OPEN_CTA_SESSION_DISMISSED_KEY) === "true";
 }
 
 export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps) {
@@ -45,9 +53,11 @@ export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps)
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
       let isDismissed = false;
+      let forceShow = false;
 
       try {
-        isDismissed = window.localStorage.getItem(APP_OPEN_CTA_DISMISSED_KEY) === "true";
+        forceShow = shouldForceShowCta();
+        isDismissed = forceShow ? false : isAppOpenCtaDismissedInSession();
       } catch {
         isDismissed = false;
       }
@@ -102,9 +112,9 @@ export default function AppOpenCta({ appPath, className = "" }: AppOpenCtaProps)
     cleanupDismissTimeout();
 
     try {
-      window.localStorage.setItem(APP_OPEN_CTA_DISMISSED_KEY, "true");
+      window.sessionStorage.setItem(APP_OPEN_CTA_SESSION_DISMISSED_KEY, "true");
     } catch {
-      // localStorage 접근이 막혀도 현재 화면에서는 즉시 숨긴다.
+      // sessionStorage 접근이 막혀도 현재 화면에서는 즉시 숨긴다.
     }
 
     setIsClosing(true);

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -3,3 +3,22 @@ export const EXTERNAL_LINKS = {
     ALADIN_BESTSELLER_URL: "https://www.aladin.co.kr/shop/common/wbest.aspx?BranchType=1&srsltid=AfmBOoormYbm3TGHXQJYOcGgci2IQp6ytpjw-CJgV2wQALS9lsE5-pTo",
     NEWS_FROM_URL: "https://forms.gle/7ZBdXSn9BnR7MC6N6",
 } as const;
+
+export const CHECKMO_APP_LINKS = {
+    IOS_APP_STORE_ID: process.env.NEXT_PUBLIC_CHECKMO_IOS_APP_STORE_ID ?? "6777671102",
+    IOS_APP_STORE_URL:
+        process.env.NEXT_PUBLIC_CHECKMO_IOS_APP_STORE_URL ?? "https://apps.apple.com/app/id6777671102",
+    FRONTEND_URL: process.env.NEXT_PUBLIC_FRONTEND_URL ?? "https://www.checkmo.co.kr",
+    APP_SCHEME: "checkmo",
+} as const;
+
+export function buildCheckmoWebUrl(path: string) {
+    const baseUrl = CHECKMO_APP_LINKS.FRONTEND_URL.replace(/\/+$/, "");
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${baseUrl}${normalizedPath}`;
+}
+
+export function buildCheckmoAppUrl(path: string) {
+    const normalizedPath = path.replace(/^\/+/, "");
+    return `${CHECKMO_APP_LINKS.APP_SCHEME}://${normalizedPath}`;
+}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 변경 사항에 대한 간략한 요약을 적어주세요.
- 관련 이슈가 있다면 링크를 걸어주세요 (예: #123).

## 🛠️ 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  * Added an iOS/iPadOS-only “앱에서 바로 보기 / 앱 열기” CTA on story detail pages, with a dismiss option remembered across visits.
  * Enhanced story detail SEO with Apple Smart App Banner metadata to improve app-opening prompts in Safari.

- **Bug Fixes**
  * Improved story detail page behavior so like/follow/delete actions initialize correctly even when an invalid story ID is accessed.
  * Updated metadata generation so non-success paths still include the app banner metadata instead of only the default title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->