### PR TITLE
Fix: 웹 QA 버그 수정 (모임 이름 중복확인, 검색 좋아요 동기화, 무한 스크롤 총 개수 오류)

### DIFF
--- a/src/app/(main)/groups/[id]/admin/edit/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/edit/page.tsx
@@ -24,6 +24,7 @@ import { useUploadClubImageMutation } from "@/hooks/mutations/useCreateClubMutat
 // ✅ 너가 방금 만들라고 한 edit용 hooks
 import { useClubAdminDetailQuery } from "@/hooks/queries/useClubAdminEditQueries";
 import { useUpdateClubAdminMutation } from "@/hooks/mutations/useClubAdminEditMutations";
+import { useClubNameCheckMutation } from "@/hooks/queries/useCreateClubQueries";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { clampTextToLimit, isTextOverLimit } from "@/utils/inputLimit";
@@ -66,6 +67,7 @@ export default function EditClubPage() {
   // ===== create랑 동일한 state 구조 유지 =====
   // Step 1
   const [clubName, setClubName] = useState("");
+  const checkNameMutation = useClubNameCheckMutation(); // ✅ edit에서도 중복확인 쿼리 사용
   const [clubDescription, setClubDescription] = useState("");
   const [nameCheck, setNameCheck] = useState<NameCheckState>("idle");
 
@@ -164,14 +166,18 @@ export default function EditClubPage() {
       return;
     }
 
-    // 여기서 실제 중복체크 훅이 있다면 create 페이지처럼 refetch하면 됨.
-    // 지금은 “UI 동일”이 목표라, 최소 동작만(나중에 hook 연결) 형태로 둠.
+    // 실제 중복체크 mutation 호출
     setNameCheck("checking");
     try {
-      // TODO: useClubNameCheckQuery(name).refetch() 연결
-      // 임시: 무조건 available 처리
-      setNameCheck("available");
-      toast.success("사용 가능한 모임 이름입니다.");
+      const isDuplicate = await checkNameMutation.mutateAsync(name);
+
+      if (isDuplicate) {
+        setNameCheck("duplicate");
+        toast.error("이미 존재하는 모임 이름입니다.");
+      } else {
+        setNameCheck("available");
+        toast.success("사용 가능한 모임 이름입니다.");
+      }
     } catch {
       setNameCheck("idle");
       toast.error("이름 중복 확인 실패");

--- a/src/app/(main)/groups/create/CreateGroupPageClient.tsx
+++ b/src/app/(main)/groups/create/CreateGroupPageClient.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/types/groups/groups";
 
 import { mapBookCategoriesToCodes } from "@/types/groups/clubCreate";
-import { useClubNameCheckQuery } from "@/hooks/queries/useCreateClubQueries";
+import { useClubNameCheckMutation } from "@/hooks/queries/useCreateClubQueries";
 import {
   useCreateClubMutation,
   useUploadClubImageMutation,
@@ -80,7 +80,7 @@ export default function CreateGroupPageClient() {
   const [links, setLinks] = useState<SnsLink[]>([{ label: "", url: "" }]);
 
   // API hooks
-  const nameQuery = useClubNameCheckQuery(clubName); // enabled:false라 버튼에서 refetch로만 호출됨
+  const checkNameMutation = useClubNameCheckMutation();
   const uploadImage = useUploadClubImageMutation();
   const createClub = useCreateClubMutation();
 
@@ -139,8 +139,7 @@ export default function CreateGroupPageClient() {
     setNameCheck("checking");
 
     try {
-      const r = await nameQuery.refetch();
-      const isDuplicate = r.data; // boolean
+      const isDuplicate = await checkNameMutation.mutateAsync(name);
 
       if (isDuplicate) {
         setNameCheck("duplicate");

--- a/src/app/(main)/news/NewsPageClient.tsx
+++ b/src/app/(main)/news/NewsPageClient.tsx
@@ -46,7 +46,7 @@ export default function NewsPageClient() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] px-4 overflow-x-hidden no-scrollbar pb-20">
+    <div className="mx-auto w-full max-w-[1400px] px-4 overflow-x-hidden no-scrollbar pb-8 d:pb-20">
       <div className="flex justify-center items-center mt-7 mb-3 t:mb-6">
         <NewsListBanner />
       </div>
@@ -68,8 +68,7 @@ export default function NewsPageClient() {
           </div>
         ) : (
           <div
-            className="flex flex-col gap-4 overflow-y-auto no-scrollbar pr-2"
-            style={{ maxHeight: "calc(100vh - 400px)", minHeight: "400px" }}
+            className="flex flex-col gap-4 overflow-y-auto no-scrollbar pr-2 max-h-[calc(100vh-200px)] d:max-h-[calc(100vh-400px)] min-h-[400px]"
           >
             {newsList.map((news) => (
               <NewsList
@@ -91,7 +90,7 @@ export default function NewsPageClient() {
         )}
       </section>
 
-      <div className="w-full my-8 border-b-4 border-Gray-1"></div>
+      <div className="hidden d:block w-full my-8 border-b-4 border-Gray-1"></div>
 
       {!isLoadingRecommended && recommendedBooks.length > 0 && (
         <TodayRecommendedBooks books={recommendedBooks} className="hidden d:flex" />

--- a/src/app/(main)/search/SearchPageClient.tsx
+++ b/src/app/(main)/search/SearchPageClient.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Image from "next/image";
 import SearchBookResult from "@/components/base-ui/Search/search_bookresult";
 import { useInfiniteBookSearchQuery } from "@/hooks/queries/useBookQueries";
+import { useToggleBookLikeMutation } from "@/hooks/mutations/useBookMutations";
 import { useInView } from "react-intersection-observer";
 
 function SearchContent() {
@@ -12,7 +13,7 @@ function SearchContent() {
   const router = useRouter();
   const query = searchParams.get("q") || "";
   const [searchValue, setSearchValue] = useState(query);
-  const [likedResults, setLikedResults] = useState<Record<string, boolean>>({});
+  const { mutate: toggleLike } = useToggleBookLikeMutation();
 
   useEffect(() => {
     setSearchValue(query);
@@ -52,7 +53,7 @@ function SearchContent() {
 
   const totalResults = useMemo(() => {
     return searchResults.length;
-  }, [searchResults]);
+  }, [searchResults.length]);
 
   return (
     <>
@@ -110,10 +111,8 @@ function SearchContent() {
                 title={result.title}
                 author={result.author}
                 detail={result.description}
-                liked={likedResults[result.isbn] || false}
-                onLikeChange={(liked) =>
-                  setLikedResults((prev) => ({ ...prev, [result.isbn]: liked }))
-                }
+                liked={result.likedByMe ?? false}
+                onLikeChange={() => toggleLike(result.isbn)}
                 onPencilClick={() => {
                   router.push(`/books/${result.isbn}`);
                 }}

--- a/src/app/(main)/search/SearchPageClient.tsx
+++ b/src/app/(main)/search/SearchPageClient.tsx
@@ -52,8 +52,14 @@ function SearchContent() {
   }, [searchData]);
 
   const totalResults = useMemo(() => {
+    // API 명세의 totalResults를 우선적으로 사용 (첫 번째 페이지 응답 기준)
+    const apiTotal = searchData?.pages[0]?.totalResults;
+    if (typeof apiTotal === "number") {
+      return apiTotal;
+    }
+    // API에 반영되지 않은 경우를 대비한 안전 장치(Fallback)
     return searchResults.length;
-  }, [searchResults.length]);
+  }, [searchData, searchResults.length]);
 
   return (
     <>

--- a/src/components/base-ui/Login/components/LoginForm.tsx
+++ b/src/components/base-ui/Login/components/LoginForm.tsx
@@ -54,7 +54,7 @@ export default function LoginForm({
             value={form.password}
             onChange={onChange}
             placeholder="비밀번호"
-            className={`flex w-full h-[32px] t:h-[44px] pl-4 pr-10 py-3 items-center rounded-lg border bg-white outline-none text-sm leading-[145%] text-Gray-7 transition-colors placeholder:text-Gray-3 disabled:cursor-not-allowed disabled:opacity-60 ${
+            className={`flex w-full h-[32px] t:h-[44px] pl-4 pr-14 py-3 items-center rounded-lg border bg-white outline-none text-sm leading-[145%] text-Gray-7 transition-colors placeholder:text-Gray-3 disabled:cursor-not-allowed disabled:opacity-60 ${
               errors?.password ? "border-Red" : "border-Subbrown-4 focus:border-primary-1"
             }`}
             onKeyDown={onKeyDown}
@@ -62,7 +62,7 @@ export default function LoginForm({
           />
           <button
             type="button"
-            className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center text-[#BBB] hover:text-[#8D8D8D] cursor-pointer"
+            className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center justify-center text-[#BBB] hover:text-[#8D8D8D] cursor-pointer"
             onClick={() => setShowPassword((prev) => !prev)}
             tabIndex={-1}
           >

--- a/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Recommendation/list_subscribe_large.tsx
@@ -27,7 +27,7 @@ function ListSubscribeElementLarge({
 }: ListSubscribeElementLargeProps) {
   return (
     <div
-      className={`flex w-full t:w-[296px] h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white transition-colors group ${onProfileClick ? "cursor-pointer hover:bg-stone-100" : ""}`}
+      className={`flex w-full h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white transition-colors group ${onProfileClick ? "cursor-pointer hover:bg-stone-100" : ""}`}
       onClick={onProfileClick}
       role={onProfileClick ? "button" : undefined}
       tabIndex={onProfileClick ? 0 : -1}
@@ -97,7 +97,7 @@ export default function ListSubscribeLarge({
 
   return (
     <section
-      className={`w-full t:w-[336px] ${height} rounded-lg border-2 border-Subbrown-4 bg-stone-50 p-5`}
+      className={`w-full max-w-[336px] ${height} rounded-lg border-2 border-Subbrown-4 bg-stone-50 p-5`}
     >
       {!hideTitle && <h3 className="subhead_2 text-Gray-7">사용자 추천</h3>}
 

--- a/src/components/base-ui/home/Subscription/list_subscribe_large.tsx
+++ b/src/components/base-ui/home/Subscription/list_subscribe_large.tsx
@@ -24,7 +24,7 @@ function ListSubscribeElementLarge({
   isFollowing = false,
 }: ListSubscribeElementLargeProps) {
   return (
-    <div className="flex w-[296px] h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white">
+    <div className="flex w-full h-[66px] px-[14px] py-[8px] gap-[8px] rounded-[8px] border border-Subbrown-4 bg-white">
       <div className="w-[32px] h-[32px] rounded-full overflow-hidden shrink-0 relative self-center">
         <Image
           src={isValidUrl(profileSrc) ? profileSrc : DEFAULT_PROFILE_IMAGE}
@@ -83,7 +83,7 @@ export default function ListSubscribeLarge({
 
   return (
     <section
-      className={`w-[336px] ${height} rounded-lg border-2 border-Subbrown-4 bg-stone-50 p-5`}
+      className={`w-full max-w-[336px] h-[380px] rounded-lg border border-Subbrown-4 bg-stone-50 px-5 pt-5 pb-6`}
     >
       <h3 className="subhead_2 text-Gray-7">사용자 추천</h3>
 

--- a/src/hooks/queries/useCreateClubQueries.ts
+++ b/src/hooks/queries/useCreateClubQueries.ts
@@ -1,17 +1,13 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { clubService } from "@/services/clubService";
 
-export const useClubNameCheckQuery = (clubName: string) => {
-  const name = clubName.trim();
-
-  return useQuery({
-    queryKey: ["clubs", "check-name", name],
-    queryFn: async () => {
-      const res = await clubService.checkNameDuplicate(name);
-      return res.result;
+export const useClubNameCheckMutation = () => {
+  return useMutation({
+    mutationFn: async (clubName: string) => {
+      const res = await clubService.checkNameDuplicate(clubName);
+      return res.result; // true(중복), false(사용가능)
     },
-    enabled: false,
   });
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -13,7 +13,7 @@ export interface BookSearchResponse {
     detailInfoList: Book[];
     hasNext: boolean;
     currentPage: number;
-    nextCursor?: number;
+    totalResults: number;
 }
 
 export interface MyLikedBooksResponse {


### PR DESCRIPTION
## 📌 개요 (Summary)
- **모임 이름 중복 확인 버그 수정**: API 실패 시에도 잘못된 결과("사용 가능한 모임 이름입니다")가 노출되던 문제를 명시적 에러 핸들링이 가능한 `useMutation` 구조로 변경하여 해결했습니다.
- **책 검색 좋아요 상태 동기화**: 검색 페이지의 불필요한 지역 상태(`useState`)를 제거하고, React Query의 전역 캐시(Server State)를 바라보도록 수정하여 '검색-서재-상세페이지' 간의 좋아요 상태가 실시간으로 동기화되도록 개선했습니다.
- **무한 스크롤 총 검색 개수 표기 오류 수정**: 검색 시 스크롤을 내릴 때마다 총 개수가 계속 늘어나던 문제를 API 응답(`totalResults`)을 직접 참조하는 방식으로 변경하여 해결했습니다.
- 로그인 모달 비밀번호 겹침 현상 해결: 비밀번호 입력창의 텍스트가 눈(Eye) 아이콘에 가려지는 UI 버그를 우측 안쪽 여백(Padding)을 넉넉히 주어 해결했습니다.
- 관련 이슈: #482 (Web QA Bug)

## 🛠️ 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

<br/>

### 1️⃣ 모임 이름 중복 확인 개선 (`CreateGroupPageClient.tsx`, `edit/page.tsx`)
기존 `useQuery({ enabled: false })` + 수동 `refetch()` 조합의 안티 패턴을 제거하고, 단발성 사용자 이벤트에 적합한 `useMutation`으로 재설계했습니다.

```mermaid
flowchart TD
    Start(["사용자: 중복 확인 클릭"]) --> Mutate["checkNameMutation.mutateAsync(name)"]
    Mutate --> API{API 통신 상태}
    
    API -- 성공 (200) --> Check["응답 결과 (boolean)"]
    Check -- true --> Dup["토스트: 이미 존재하는 이름입니다"]
    Check -- false --> Avail["토스트: 사용 가능한 이름입니다"]
    
    API -- 실패 (네트워크 등) --> Catch["Catch 블록으로 throw 발생"]
    Catch --> Err["토스트: 이름 중복 확인 실패"]
    
    style Catch fill:#ffcccc,stroke:#ff0000,stroke-width:2px
```
- API 실패 시 `catch` 구문이 동작하여 뷰(View) 단에서 안전한 예외 처리가 가능해졌습니다.

<br/>

### 2️⃣ 검색 페이지 좋아요 전역 동기화 (`SearchPageClient.tsx`)
검색 페이지 내부에 분리되어 있던 로컬 상태(`likedResults`)를 삭제하고, `useToggleBookLikeMutation`을 연결하여 "단일 진실 공급원(Single Source of Truth)" 패턴을 확립했습니다.

```mermaid
sequenceDiagram
    participant UI as SearchPageClient
    participant Cache as React Query Cache
    participant API as 백엔드 API

    Note over UI: 기존: 지역 상태(useState)만 변경<br/>(서버 및 타 페이지와 단절)
    
    UI->>API: 1. toggleBookLike() 호출
    API-->>Cache: 2. 낙관적 업데이트 적용<br/>(infiniteSearch, likedBooks 캐시 일괄 변경)
    Cache-->>UI: 3. 캐시 동기화에 따른 UI 즉각 반영
    
    Note over UI,Cache: 내 서재, 책 상세 페이지와 실시간 100% 동기화 달성
```
- 검색 결과 목록에서 좋아요 토글 시 즉시 캐시가 갱신되어, 별도 새로고침 없이 다른 페이지에도 완벽히 반영됩니다.

<br/>

### 3️⃣ 무한 스크롤 총 개수(`totalResults`) 표기 오류 수정 (`types/book.ts`, `SearchPageClient.tsx`)
총 검색 결과를 화면에 렌더링된 누적 데이터의 길이(`length`)로 계산하던 방식을 폐기하고, 백엔드 API의 메타데이터를 신뢰하도록 수정했습니다.

```mermaid
flowchart LR
    API["백엔드 응답 (API)"] --> |"pages[0]"| P1["page 1\n{ detailInfoList: [...10개], totalResults: 52 }"]
    API --> |"pages[1]"| P2["page 2\n{ detailInfoList: [...10개], totalResults: 52 }"]
    
    P1 -.-> |참조| Total["총 검색결과 개수 표기 로직\nsearchData.pages[0].totalResults"]
    
    P1 --> |누적| List["무한 스크롤 목록 렌더링"]
    P2 --> |누적| List
    
    style Total fill:#ccffcc,stroke:#00aa00,stroke-width:2px
```
- `BookSearchResponse` 명세에 `totalResults`를 추가하고 `nextCursor`를 제거했습니다.
- 무한 스크롤이 진행되어 누적 리스트 개수가 늘어나도, 상단 총 개수는 `pages[0].totalResults`를 참조하므로 언제나 고정된 올바른 값이 표기됩니다.


### 4️⃣ 로그인 모달 비밀번호 겹침(Overlapping) 해결 (LoginForm.tsx)
비밀번호를 길게 입력할 경우, 눈(Eye) 아이콘 밑으로 텍스트 커서나 글자가 가려지는 UI/UX 결함을 "안전 구역(Safe Area)"을 넉넉히 확보하여 수정했습니다.

### 5️⃣ 사용자 추천 박스 레이아웃 및 여백 오류 수정 (list_subscribe_large.tsx)
화면 너비 변화 시 사용자 추천 박스만 크기가 달라지는 현상과 내부 리스트 아이템이 우측으로 치우쳐 렌더링되는 현상을 해결했습니다.
* 외부 너비: 부모 래퍼를 t:w-[336px]에서 max-w-[336px]로 변경하여 반응형 축소 시에도 다른 카드들과 동일하게 동작하게 맞췄습니다.
* 내부 너비: 리스트 컴포넌트의 너비를 w-full로 변경하여, 패딩과 테두리를 제외한 가용 공간(292px)에 오차 없이 꽉 차도록 여백을 교정했습니다.

### 6️⃣ 모바일 환경 새로운 소식 영역 공간 최적화 (NewsPageClient.tsx)
모바일 뷰에서 쓸모없이 낭비되던 여백과 구분선을 제거하고, 확보된 공간만큼 새로운 소식 카드들이 더 많이 렌더링되도록 스크롤 영역을 확대했습니다.
* 구분선 숨김: 데스크탑 전용 하단 추천 섹션을 가르는 회색 선을 모바일에서는 hidden d:block 처리하여 숨겼습니다.
* 여백 최소화 및 높이 확장: 전체 래퍼의 모바일 하단 여백을 pb-20에서 pb-8로 줄이고, 남는 공간만큼 리스트 컴포넌트의 max-h를 calc(100vh - 200px)로 늘려 모바일 사용자들의 스크롤 피로도를 줄였습니다.

## 📸 스크린샷 (Screenshots)
*(필요 시 UI 캡처 이미지 첨부)*

## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [x] 린트 에러가 없나요? (`pnpm lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?
