### PR TITLE
Fix/486 groups logic

### DIFF
--- a/src/app/(main)/groups/GroupsPageClient.tsx
+++ b/src/app/(main)/groups/GroupsPageClient.tsx
@@ -82,13 +82,7 @@ export default function GroupsPageClient() {
   const router = useRouter();
   const { isLoggedIn, isInitialized, openLoginModal } = useAuthStore();
 
-  useEffect(() => {
-    if (isInitialized && !isLoggedIn) {
-      toast.error("모임은 로그인이 필요한 서비스입니다.", { id: "groups-auth-error" });
-      router.replace("/");
-      setTimeout(() => { openLoginModal(); }, 100);
-    }
-  }, [isLoggedIn, isInitialized, router, openLoginModal]);
+
 
   const [q, setQ] = useState("");
   const [category, setCategory] = useState<Category>("전체");
@@ -148,7 +142,13 @@ export default function GroupsPageClient() {
   }, [isSearchMode, hasNextPage, searchFetching, fetchNextPage]);
 
   const onClickVisit = (clubId: number) => router.push(`/groups/${clubId}`);
-  const onClickApply = (clubId: number) => setApplyClubId((prev) => (prev === clubId ? null : clubId));
+  const onClickApply = (clubId: number) => {
+    if (!isLoggedIn) {
+      openLoginModal();
+      return;
+    }
+    setApplyClubId((prev) => (prev === clubId ? null : clubId));
+  };
   const onCloseApply = () => setApplyClubId(null);
 
   const onSubmitApply = async (clubId: number, reason: string) => {
@@ -185,7 +185,13 @@ export default function GroupsPageClient() {
             borderColorVar="--Primary_1"
             textColorVar="--White"
             className="flex-1 body_1 hover:-translate-y-[1px] cursor-pointer"
-            onClick={() => router.push("/groups/create")}
+            onClick={() => {
+              if (!isLoggedIn) {
+                openLoginModal();
+                return;
+              }
+              router.push("/groups/create");
+            }}
           />
         </div>
         <div className="hidden w-full t:flex mt-5 mb-4">
@@ -196,7 +202,13 @@ export default function GroupsPageClient() {
             borderColorVar="--Primary_1"
             textColorVar="--White"
             className="flex-1 subhead_4_1 hover:-translate-y-[1px] cursor-pointer"
-            onClick={() => router.push("/groups/create")}
+            onClick={() => {
+              if (!isLoggedIn) {
+                openLoginModal();
+                return;
+              }
+              router.push("/groups/create");
+            }}
           />
         </div>
         <Mybookclub groups={myGroups} isLoading={myClubsLoading} />

--- a/src/app/(main)/groups/GroupsPageClient.tsx
+++ b/src/app/(main)/groups/GroupsPageClient.tsx
@@ -142,7 +142,13 @@ export default function GroupsPageClient() {
     return () => io.disconnect();
   }, [isSearchMode, isGuestDefaultView, hasNextPage, searchFetching, fetchNextPage]);
 
-  const onClickVisit = (clubId: number) => router.push(`/groups/${clubId}`);
+  const onClickVisit = (clubId: number) => {
+    if (!isLoggedIn) {
+      openLoginModal();
+      return;
+    }
+    router.push(`/groups/${clubId}`);
+  };
   const onClickApply = (clubId: number) => {
     if (!isLoggedIn) {
       openLoginModal();

--- a/src/app/(main)/groups/GroupsPageClient.tsx
+++ b/src/app/(main)/groups/GroupsPageClient.tsx
@@ -90,6 +90,7 @@ export default function GroupsPageClient() {
   const [region, setRegion] = useState(false);
   const [appliedParams, setAppliedParams] = useState<Omit<ClubSearchParams, "cursorId"> | null>(null);
   const isSearchMode = appliedParams !== null;
+  const isGuestDefaultView = !isLoggedIn && !isSearchMode;
   const [applyClubId, setApplyClubId] = useState<number | null>(null);
 
   const { data: myClubsData, isLoading: myClubsLoading } = useMyClubsQuery(isLoggedIn);
@@ -103,7 +104,7 @@ export default function GroupsPageClient() {
     refetch: refetchSearch,
   } = useInfiniteClubSearchQuery(
     appliedParams ?? { keyword: undefined, inputFilter: null, outputFilter: "ALL" },
-    isSearchMode
+    isSearchMode || isGuestDefaultView
   );
 
   const { mutateAsync: joinAsync, isPending: joinPending } = useClubJoinMutation();
@@ -121,12 +122,12 @@ export default function GroupsPageClient() {
     return (searchData?.pages ?? []).flatMap((p) => p.clubList.map(mapSearchItem));
   }, [searchData]);
 
-  const clubsToRender = isSearchMode ? searchedClubs : recommendationClubs;
+  const clubsToRender = (isSearchMode || isGuestDefaultView) ? searchedClubs : recommendationClubs;
   const selectedClub = clubsToRender.find((c) => c.clubId === applyClubId) ?? null;
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!isSearchMode) return;
+    if (!isSearchMode && !isGuestDefaultView) return;
     const el = sentinelRef.current;
     if (!el) return;
     const io = new IntersectionObserver(
@@ -139,7 +140,7 @@ export default function GroupsPageClient() {
     );
     io.observe(el);
     return () => io.disconnect();
-  }, [isSearchMode, hasNextPage, searchFetching, fetchNextPage]);
+  }, [isSearchMode, isGuestDefaultView, hasNextPage, searchFetching, fetchNextPage]);
 
   const onClickVisit = (clubId: number) => router.push(`/groups/${clubId}`);
   const onClickApply = (clubId: number) => {
@@ -245,10 +246,10 @@ export default function GroupsPageClient() {
               />
             ))}
           </div>
-          {!isSearchMode && recLoading && (
+          {!(isSearchMode || isGuestDefaultView) && recLoading && (
             <p className="mt-3 body_2_2 text-Gray-4">불러오는 중…</p>
           )}
-          {isSearchMode && <div ref={sentinelRef} className="h-10" />}
+          {(isSearchMode || isGuestDefaultView) && <div ref={sentinelRef} className="h-10" />}
         </div>
       </main>
 

--- a/src/app/(main)/groups/[id]/GroupDetailClient.tsx
+++ b/src/app/(main)/groups/[id]/GroupDetailClient.tsx
@@ -25,7 +25,8 @@ export default function GroupDetailClient() {
   const params = useParams();
   const groupId = Number(params.id);
   const queryClient = useQueryClient();
-  const currentNickname = useAuthStore((state) => state.user?.nickname);
+  const { isLoggedIn, openLoginModal, user } = useAuthStore();
+  const currentNickname = user?.nickname;
   const toggleFollowMutation = useToggleFollowMutation();
 
   const { meQuery, homeQuery, latestNoticeQuery, nextMeetingQuery } = useClubhomeQueries(groupId);
@@ -117,6 +118,10 @@ export default function GroupDetailClient() {
   const joinUrl = joinMeetingId ? `/groups/${groupId}/bookcase/${joinMeetingId}` : null;
 
   const onClickJoin = () => {
+    if (!isLoggedIn) {
+      openLoginModal();
+      return;
+    }
     if (!canAccessMemberOnlyPage) {
       toast.error("회원만 접근이 가능합니다.");
       return;
@@ -129,6 +134,10 @@ export default function GroupDetailClient() {
   };
 
   const handleToggleFollow = (id: string | number, isFollowing: boolean) => {
+    if (!isLoggedIn) {
+      openLoginModal();
+      return;
+    }
     toggleFollowMutation.mutate(
       {
         nickname: String(id),
@@ -149,6 +158,7 @@ export default function GroupDetailClient() {
           role="button"
           tabIndex={0}
           onClick={() => {
+            if (!isLoggedIn) { openLoginModal(); return; }
             if (!canAccessMemberOnlyPage) { toast.error("회원만 접근이 가능합니다."); return; }
             if (!hasNotice) { toast.error("아직 등록된 공지사항이 없습니다."); return; }
             router.push(noticeUrl!);
@@ -156,6 +166,7 @@ export default function GroupDetailClient() {
           onKeyDown={(e) => {
             if (e.key !== "Enter" && e.key !== " ") return;
             e.preventDefault();
+            if (!isLoggedIn) { openLoginModal(); return; }
             if (!canAccessMemberOnlyPage) { toast.error("회원만 접근이 가능합니다."); return; }
             if (!hasNotice) { toast.error("아직 등록된 공지사항이 없습니다."); return; }
             router.push(noticeUrl!);

--- a/src/app/(main)/groups/[id]/layout.tsx
+++ b/src/app/(main)/groups/[id]/layout.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 
 import { useClubhomeQueries } from "@/hooks/queries/useClubhomeQueries";
 import { useClubAccessGuard } from "@/hooks/useClubAccessGuard";
+import { useAuthStore } from "@/store/useAuthStore";
 
 type TabType = "home" | "notice" | "bookcase";
 
@@ -17,6 +18,7 @@ export default function GroupDetailLayout({ children }: { children: React.ReactN
   const groupIdNum = Number(groupId);
 
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
+  const { isLoggedIn, openLoginModal } = useAuthStore();
 
   const skipLayout = useMemo(() => {
     return pathname?.includes("/admin/");
@@ -144,6 +146,12 @@ export default function GroupDetailLayout({ children }: { children: React.ReactN
                     <Link
                       key={tab.id}
                       href={tab.href}
+                      onClick={(e) => {
+                        if ((tab.id === "notice" || tab.id === "bookcase") && !isLoggedIn) {
+                          e.preventDefault();
+                          openLoginModal();
+                        }
+                      }}
                       className={`
                         flex flex-1 items-center justify-center gap-1 rounded-lg px-2 py-2
                         t:gap-3 t:px-4 t:py-3

--- a/src/components/base-ui/News/NewsListBanner.tsx
+++ b/src/components/base-ui/News/NewsListBanner.tsx
@@ -1,42 +1,37 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { useInfiniteNewsQuery } from "@/hooks/queries/useNewsQueries";
+import SwipeCarousel from "@/components/common/SwipeCarousel";
+import { useMemo } from "react";
 
 export default function NewsListBanner() {
-    const router = useRouter();
-    const [index, setIndex] = useState(0);
-
     const { data, isLoading, isError } = useInfiniteNewsQuery();
 
     const newsList = data?.pages.flatMap((page) => page.basicInfoList) || [];
 
     // 'PROMOTION' 태그가 붙은 소식만 필터링 및 게시 종료 날짜 순 정렬 (최대 5개)
-    const promotionList = useMemo(() => {
+    const carouselItems = useMemo(() => {
         return newsList
             .filter((news) => news.carousel === "PROMOTION")
             .sort((a, b) => new Date(b.publishEndAt).getTime() - new Date(a.publishEndAt).getTime())
-            .slice(0, 5);
+            .slice(0, 5)
+            .map((news) => {
+                const isValidSrc = news.thumbnailUrl && news.thumbnailUrl !== "string" && 
+                    (news.thumbnailUrl.startsWith("/") || news.thumbnailUrl.startsWith("http"));
+                    
+                return {
+                    id: news.newsId,
+                    imageUrl: isValidSrc ? news.thumbnailUrl : "/news_sample.svg",
+                    title: news.title,
+                    description: news.description,
+                    link: `/news/${news.newsId}`,
+                };
+            });
     }, [newsList]);
-
-    const slideCount = promotionList.length;
-
-    // 5초 자동 슬라이드 로직
-    useEffect(() => {
-        if (slideCount <= 1) return;
-
-        const timer = setInterval(() => {
-            setIndex((prevIndex) => (prevIndex + 1) % slideCount);
-        }, 5000);
-
-        return () => clearInterval(timer);
-    }, [slideCount]);
 
     if (isLoading) {
         return (
-            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] bg-gray-100 animate-pulse flex items-center justify-center">
+            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] mx-auto overflow-hidden rounded-[10px] bg-gray-100 animate-pulse flex items-center justify-center">
                 <div className="text-gray-400">소식을 불러오는 중...</div>
             </div>
         );
@@ -44,83 +39,26 @@ export default function NewsListBanner() {
 
     if (isError) {
         return (
-            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1">
+            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] mx-auto overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1">
                 <div className="text-gray-400 text-lg font-medium">소식을 불러오지 못했어요.</div>
             </div>
         );
     }
 
-    if (slideCount === 0) {
+    if (carouselItems.length === 0) {
         return (
-            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1">
+            <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] mx-auto overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1">
                 <div className="text-gray-400 text-lg font-medium text-center px-4">책모의 소식에서 다양한 책 관련 행사를 알아보세요!</div>
             </div>
         );
     }
 
-    const safeIndex = index % slideCount;
-
-    const isValidSrc = (src: string) => {
-        return src && src !== "string" && (src.startsWith("/") || src.startsWith("http://") || src.startsWith("https://"));
-    };
-
     return (
-        <div className="relative h-[297px] t:h-[468px] w-full max-w-[1040px] overflow-hidden rounded-[10px] shadow-sm">
-            {promotionList.map((news, i) => {
-                const imageSrc = isValidSrc(news.thumbnailUrl) ? news.thumbnailUrl : "/news_sample.svg";
-                const isActive = i === safeIndex;
-
-                return (
-                    <div
-                        key={news.newsId}
-                        className={`absolute inset-0 w-full h-full cursor-pointer group transition-opacity duration-700 ease-in-out ${isActive ? "opacity-100 z-10" : "opacity-0 z-0 pointer-events-none"
-                            }`}
-                        onClick={() => router.push(`/news/${news.newsId}`)}
-                    >
-                        <Image
-                            src={imageSrc}
-                            alt={news.title}
-                            fill
-                            className="object-cover object-left-top transition-transform duration-700 group-hover:scale-105"
-                            priority={i === 0}
-                        />
-
-                        {/* Text Overlay - 텍스트 포함 요청 반영 */}
-                        <div className="absolute inset-y-0 right-0 w-full md:w-1/2 p-6 t:p-10 flex flex-col justify-center items-end bg-gradient-to-l from-black/90 via-black/50 to-transparent text-right">
-                            <div className="flex flex-col gap-2 t:gap-3 text-white">
-                                <h3 className="text-xl t:text-3xl font-bold leading-tight drop-shadow-lg">
-                                    {news.title}
-                                </h3>
-                                <p className="text-xs t:text-base text-white/90 line-clamp-3 t:line-clamp-4 max-w-[240px] t:max-w-[400px] whitespace-pre-line drop-shadow-md font-light">
-                                    {news.description}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                );
-            })}
-
-            {/* 인디케이터 */}
-            <div className="absolute top-[20px] left-[20px] t:top-[27px] t:left-[33px] flex gap-2 z-20">
-                {promotionList.map((_, i) => {
-                    const active = i === safeIndex;
-
-                    return (
-                        <button
-                            key={i}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                setIndex(i);
-                            }}
-                            aria-label={`배너 ${i + 1}`}
-                            className={`transition-all duration-300 ${active
-                                    ? "w-6 h-2 rounded-[100px] bg-primary-1"
-                                    : "w-2 h-2 rounded-full bg-white/50 hover:bg-white"
-                                }`}
-                        />
-                    );
-                })}
-            </div>
-        </div>
+        <SwipeCarousel 
+            items={carouselItems}
+            heightClass="h-[297px] t:h-[468px]"
+            maxWidthClass="w-full max-w-[1040px]"
+            showTitleLarge={true}
+        />
     );
 }

--- a/src/components/base-ui/home/News/NewsBannerSlider.tsx
+++ b/src/components/base-ui/home/News/NewsBannerSlider.tsx
@@ -1,29 +1,28 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { useInfiniteNewsQuery } from "@/hooks/queries/useNewsQueries";
+import SwipeCarousel from "@/components/common/SwipeCarousel";
+import { useMemo } from "react";
 
 export default function NewsBannerSlider() {
-  const router = useRouter();
-  const [index, setIndex] = useState(0);
-
   const { data, isLoading, isError } = useInfiniteNewsQuery();
 
   const newsList = data?.pages.flatMap((page) => page.basicInfoList) || [];
-
-  // 5초 자동 슬라이드 로직
-  useEffect(() => {
-    const slideCount = Math.min(newsList.length, 5);
-    if (slideCount <= 1) return;
-
-    const timer = setInterval(() => {
-      setIndex((prevIndex) => (prevIndex + 1) % slideCount);
-    }, 5000);
-
-    return () => clearInterval(timer);
-  }, [newsList.length]);
+  
+  const carouselItems = useMemo(() => {
+    return newsList.slice(0, 5).map((news) => {
+      const isValidSrc = news.thumbnailUrl && news.thumbnailUrl !== "string" && 
+        (news.thumbnailUrl.startsWith("/") || news.thumbnailUrl.startsWith("http"));
+        
+      return {
+        id: news.newsId,
+        imageUrl: isValidSrc ? news.thumbnailUrl : "/news_sample.svg",
+        title: news.title,
+        description: news.description,
+        link: `/news/${news.newsId}`,
+      };
+    });
+  }, [newsList]);
 
   if (isLoading) {
     return (
@@ -33,7 +32,7 @@ export default function NewsBannerSlider() {
     );
   }
 
-  if (isError || newsList.length === 0) {
+  if (isError || carouselItems.length === 0) {
     return (
       <div className="relative h-[297px] t:h-[424px] w-full overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2">
         <div className="text-gray-400 text-lg font-medium">새로운 소식이 아직 없어요!</div>
@@ -41,68 +40,13 @@ export default function NewsBannerSlider() {
       </div>
     );
   }
-  const isValidSrc = (src: string) => {
-    return src && src !== "string" && (src.startsWith("/") || src.startsWith("http://") || src.startsWith("https://"));
-  };
-  // Dot navigation only shows max 5
-  const slideCount = Math.min(newsList.length, 5);
-  const safeIndex = index % slideCount;
 
   return (
-    <div className="relative h-[297px] t:h-[424px] w-full overflow-hidden rounded-[10px]">
-      {newsList.slice(0, slideCount).map((news, i) => {
-        const imageSrc = isValidSrc(news.thumbnailUrl) ? news.thumbnailUrl : "/news_sample.svg";
-        const isActive = i === safeIndex;
-
-        return (
-          <div
-            key={news.newsId}
-            className={`absolute inset-0 w-full h-full cursor-pointer group transition-opacity duration-700 ease-in-out ${isActive ? "opacity-100 z-10" : "opacity-0 z-0 pointer-events-none"
-              }`}
-            onClick={() => router.push(`/news/${news.newsId}`)}
-          >
-            <Image
-              src={imageSrc}
-              alt={news.title}
-              fill
-              className="object-cover object-left-top transition-transform duration-700 group-hover:scale-105"
-              priority={i === 0}
-            />
-
-            {/* Text Overlay */}
-            <div className="absolute inset-y-0 right-0 w-1/2 p-6 t:p-10 flex flex-col justify-center items-end bg-gradient-to-l from-black/90 via-black/50 to-transparent text-right">
-              <div className="flex flex-col gap-2 t:gap-3 text-white">
-                <h3 className="text-2xl t:text-4xl font-bold leading-tight drop-shadow-md">
-                  {news.title}
-                </h3>
-                <p className="text-sm t:text-lg text-white/90 line-clamp-4 max-w-[280px] t:max-w-[400px] whitespace-pre-line drop-shadow-sm">
-                  {news.description}
-                </p>
-              </div>
-            </div>
-          </div>
-        );
-      })}
-
-      <div className="absolute top-[27px] left-[33px] flex gap-2 z-20">
-        {newsList.slice(0, slideCount).map((_, i) => {
-          const active = i === safeIndex;
-
-          return (
-            <button
-              key={i}
-              onClick={() => setIndex(i)}
-              aria-label={`배너 ${i + 1}`}
-              className={[
-                "transition-all duration-300",
-                active
-                  ? "w-6.5 h-2.5 rounded-[100px] bg-primary-1"
-                  : "w-2.5 h-2.5 rounded-full bg-Subbrown-2",
-              ].join(" ")}
-            />
-          );
-        })}
-      </div>
-    </div>
+    <SwipeCarousel 
+      items={carouselItems}
+      heightClass="h-[297px] t:h-[424px]"
+      maxWidthClass="w-full"
+      showTitleLarge={false}
+    />
   );
 }

--- a/src/components/common/SwipeCarousel.tsx
+++ b/src/components/common/SwipeCarousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { motion, useMotionValue, useMotionValueEvent, animate } from "framer-motion";
@@ -66,7 +66,7 @@ export default function SwipeCarousel({
   const nextIndex = slideCount > 0 ? wrap(0, slideCount, renderIndex + 1) : 0;
 
   // x 좌표를 실시간 추적하여 절반 이상 넘어갔을 때 인디케이터를 선제적으로 교체
-  useMotionValueEvent(x, "change", (latestX) => {
+  const handleXChange = useCallback((latestX: number) => {
     if (!containerRef.current || slideCount <= 1) return;
     const containerWidth = containerRef.current.offsetWidth;
     
@@ -78,10 +78,14 @@ export default function SwipeCarousel({
     }
 
     const newIndicatorIndex = wrap(0, slideCount, renderIndexRef.current + offsetIndex);
-    if (newIndicatorIndex !== indicatorIndex) {
-      setIndicatorIndex(newIndicatorIndex);
-    }
-  });
+    
+    setIndicatorIndex((prev) => {
+      if (prev !== newIndicatorIndex) return newIndicatorIndex;
+      return prev;
+    });
+  }, [slideCount]);
+
+  useMotionValueEvent(x, "change", handleXChange);
 
   const navigateToSlide = (direction: number) => {
     if (slideCount <= 1) return;

--- a/src/components/common/SwipeCarousel.tsx
+++ b/src/components/common/SwipeCarousel.tsx
@@ -141,6 +141,7 @@ export default function SwipeCarousel({
   const renderCard = (item: CarouselItem, position: string) => {
     return (
       <div
+        key={position}
         className="absolute top-0 bottom-0 w-full flex-shrink-0"
         style={{ left: position }}
       >

--- a/src/components/common/SwipeCarousel.tsx
+++ b/src/components/common/SwipeCarousel.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { motion, useMotionValue, useMotionValueEvent, animate } from "framer-motion";
+
+export interface CarouselItem {
+  id: string | number;
+  imageUrl: string;
+  title: string;
+  description: string;
+  link: string; // The URL to navigate to
+}
+
+interface SwipeCarouselProps {
+  items: CarouselItem[];
+  autoPlayInterval?: number;
+  heightClass?: string; // e.g. "h-[297px] t:h-[424px]"
+  maxWidthClass?: string; // e.g. "w-full max-w-[1040px]"
+  showTitleLarge?: boolean; // Controls whether to show large text (for NewsListBanner) or normal (for NewsBannerSlider)
+}
+
+const swipeConfidenceThreshold = 10000;
+const swipePower = (offset: number, velocity: number) => {
+  return Math.abs(offset) * velocity;
+};
+
+// 음수 인덱스 처리 및 배열 범위를 안전하게 순환하기 위한 함수
+const wrap = (min: number, max: number, v: number) => {
+  const rangeSize = max - min;
+  return ((((v - min) % rangeSize) + rangeSize) % rangeSize) + min;
+};
+
+export default function SwipeCarousel({
+  items,
+  autoPlayInterval = 5000,
+  heightClass = "h-[297px] t:h-[424px]",
+  maxWidthClass = "w-full",
+  showTitleLarge = false,
+}: SwipeCarouselProps) {
+  const router = useRouter();
+  
+  // 렌더링용 인덱스 (DOM 요소 재배치용, 애니메이션 완료 시점에 업데이트)
+  const [renderIndex, setRenderIndex] = useState(0);
+  const renderIndexRef = useRef(renderIndex);
+  
+  // React 상태와 Ref를 즉각적으로 동기화하는 헬퍼 함수
+  const updateRenderIndex = (newIndex: number) => {
+    renderIndexRef.current = newIndex;
+    setRenderIndex(newIndex);
+  };
+  
+  // 시각용 인덱스 (하단 점선 인디케이터용, 드래그 중 실시간 업데이트)
+  const [indicatorIndex, setIndicatorIndex] = useState(0);
+
+  const x = useMotionValue(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const slideCount = items.length;
+  const safeIndex = slideCount > 0 ? wrap(0, slideCount, renderIndex) : 0;
+
+  // 가상화: 이전, 현재, 다음 카드만 렌더링
+  const prevIndex = slideCount > 0 ? wrap(0, slideCount, renderIndex - 1) : 0;
+  const nextIndex = slideCount > 0 ? wrap(0, slideCount, renderIndex + 1) : 0;
+
+  // x 좌표를 실시간 추적하여 절반 이상 넘어갔을 때 인디케이터를 선제적으로 교체
+  useMotionValueEvent(x, "change", (latestX) => {
+    if (!containerRef.current || slideCount <= 1) return;
+    const containerWidth = containerRef.current.offsetWidth;
+    
+    let offsetIndex = 0;
+    if (latestX <= -containerWidth / 2) {
+      offsetIndex = 1;
+    } else if (latestX >= containerWidth / 2) {
+      offsetIndex = -1;
+    }
+
+    const newIndicatorIndex = wrap(0, slideCount, renderIndexRef.current + offsetIndex);
+    if (newIndicatorIndex !== indicatorIndex) {
+      setIndicatorIndex(newIndicatorIndex);
+    }
+  });
+
+  const navigateToSlide = (direction: number) => {
+    if (slideCount <= 1) return;
+    const containerWidth = containerRef.current?.offsetWidth || 0;
+    const targetX = direction > 0 ? -containerWidth : containerWidth;
+
+    animate(x, targetX, {
+      type: "spring",
+      stiffness: 300,
+      damping: 30,
+      onComplete: () => {
+        // 애니메이션이 끝나면 렌더링 인덱스를 동기화하고 x를 즉시 초기화
+        const newRenderIndex = renderIndexRef.current + direction;
+        updateRenderIndex(newRenderIndex); // Ref를 즉시 변경하여 꼬임 방지
+        setIndicatorIndex(wrap(0, slideCount, newRenderIndex));
+        x.set(0); // 이 순간 change 이벤트가 트리거되어도 최신 Ref를 바라봄
+      },
+    });
+  };
+
+  const jumpTo = (targetIdx: number) => {
+    if (slideCount <= 1) return;
+    const diff = targetIdx - indicatorIndex;
+    if (diff === 0) return;
+
+    // 인디케이터 클릭 시엔 즉각적으로 두 인덱스를 모두 동기화
+    const newRenderIndex = renderIndexRef.current + diff;
+    updateRenderIndex(newRenderIndex);
+    setIndicatorIndex(targetIdx);
+    x.set(0);
+  };
+
+  useEffect(() => {
+    if (slideCount <= 1 || autoPlayInterval <= 0) return;
+    
+    if (isDragging) return;
+
+    const timer = setInterval(() => {
+      navigateToSlide(1);
+    }, autoPlayInterval);
+
+    return () => clearInterval(timer);
+  }, [slideCount, renderIndex, autoPlayInterval, isDragging]);
+
+  if (slideCount === 0) {
+    return (
+      <div className={`relative ${heightClass} ${maxWidthClass} mx-auto overflow-hidden rounded-[10px] bg-gray-50 flex flex-col items-center justify-center gap-2 border border-Gray-1`}>
+        <div className="text-gray-400 text-lg font-medium text-center px-4">표시할 내용이 없습니다.</div>
+      </div>
+    );
+  }
+
+  const renderCard = (item: CarouselItem, position: string) => {
+    return (
+      <div
+        className="absolute top-0 bottom-0 w-full flex-shrink-0"
+        style={{ left: position }}
+      >
+        <div 
+          className="w-full h-full relative cursor-pointer"
+          onClick={() => {
+            if (isDragging) return; // 드래그 중 클릭 방지
+            router.push(item.link);
+          }}
+        >
+          <Image
+            src={item.imageUrl}
+            alt={item.title}
+            fill
+            className="object-cover object-left-top transition-transform duration-700 hover:scale-105 pointer-events-none"
+            priority={position === "0%"}
+            draggable={false}
+          />
+          <div className="absolute inset-y-0 right-0 w-full md:w-1/2 p-6 t:p-10 flex flex-col justify-center items-end bg-gradient-to-l from-black/90 via-black/50 to-transparent text-right pointer-events-none">
+            <div className="flex flex-col gap-2 t:gap-3 text-white">
+              <h3 className={`${showTitleLarge ? "text-xl t:text-3xl" : "text-2xl t:text-4xl"} font-bold leading-tight drop-shadow-md`}>
+                {item.title}
+              </h3>
+              <p className={`${showTitleLarge ? "text-xs t:text-base line-clamp-3 t:line-clamp-4 max-w-[240px]" : "text-sm t:text-lg line-clamp-4 max-w-[280px]"} t:max-w-[400px] whitespace-pre-line drop-shadow-sm font-light`}>
+                {item.description}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div 
+      ref={containerRef}
+      className={`relative ${heightClass} ${maxWidthClass} mx-auto overflow-hidden rounded-[10px] shadow-sm`}
+    >
+      {/* 
+        기차 트랙 (Continuous Track)
+        overflow-hidden 부모 안에서 드래그 가능하며, 모바일 세로 스크롤 방지를 위해 touchAction pan-y 적용
+      */}
+      <motion.div
+        className="absolute inset-0 w-full h-full"
+        style={{ x, touchAction: "pan-y" }}
+        drag={slideCount > 1 ? "x" : false}
+        dragConstraints={{ left: 0, right: 0 }} // 놓았을 때 탄성으로 돌아가게 설정
+        dragElastic={1} // 1: 1대1로 따라옴
+        onDragStart={() => setIsDragging(true)}
+        onDragEnd={(e, { offset, velocity }) => {
+          // 약간의 딜레이를 주어 드래그 직후 발생하는 onClick 이벤트 무시
+          setTimeout(() => setIsDragging(false), 50); 
+          const swipe = swipePower(offset.x, velocity.x);
+          const containerWidth = containerRef.current?.offsetWidth || 0;
+          
+          // 강하게 드래그했거나 화면의 절반 이상을 드래그했으면 이동
+          if (swipe < -swipeConfidenceThreshold || offset.x < -containerWidth / 2) {
+            navigateToSlide(1); // 다음 슬라이드
+          } else if (swipe > swipeConfidenceThreshold || offset.x > containerWidth / 2) {
+            navigateToSlide(-1); // 이전 슬라이드
+          } else {
+            // 제자리 스냅
+            animate(x, 0, { type: "spring", stiffness: 300, damping: 30 });
+          }
+        }}
+      >
+        {/* 가상화 렌더링: 이전(-100%), 현재(0%), 다음(100%) */}
+        {slideCount > 1 && renderCard(items[prevIndex], "-100%")}
+        {renderCard(items[safeIndex], "0%")}
+        {slideCount > 1 && renderCard(items[nextIndex], "100%")}
+      </motion.div>
+
+      {/* 인디케이터 */}
+      {slideCount > 1 && (
+        <div className="absolute top-[20px] left-[20px] t:top-[27px] t:left-[33px] flex gap-2 z-20">
+          {items.map((_, i) => {
+            const active = i === indicatorIndex;
+            return (
+              <button
+                key={i}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  jumpTo(i);
+                }}
+                aria-label={`배너 ${i + 1}`}
+                className={`transition-all duration-300 ${
+                  active
+                    ? "w-6 h-2 rounded-[100px] bg-primary-1"
+                    : "w-2 h-2 rounded-full bg-white/50 hover:bg-white"
+                }`}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { usePathname, useRouter } from "next/navigation";
-import { useAuthStore } from "@/store/useAuthStore";
+import { usePathname } from "next/navigation";
 
 
 const NAV_ITEMS = [
@@ -41,18 +40,8 @@ const NAV_ITEMS = [
 
 export default function BottomNav() {
   const pathname = usePathname();
-  const router = useRouter();
-  const { isLoggedIn, openLoginModal } = useAuthStore();
 
   if (pathname === "/landing") return null;
-
-  const handleNavClick = (e: React.MouseEvent, href: string, label: string) => {
-    if (label === "모임" && !isLoggedIn) {
-      e.preventDefault();
-      openLoginModal();
-      return;
-    }
-  };
 
   return (
     <>
@@ -69,7 +58,6 @@ export default function BottomNav() {
               <Link
                 key={item.href}
                 href={item.href}
-                onClick={(e) => handleNavClick(e, item.href, item.label)}
                 className="flex flex-col items-center justify-center gap-1 py-2 "
               >
                 <div className="relative w-12 h-12">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ export default function Header() {
   const router = useRouter();
   const defaultTitle = getPageTitle(pathname);
   const { customTitle } = useHeaderTitle();
-  const { user, isLoggedIn, openLoginModal } = useAuthStore();
+  const { user, isLoggedIn } = useAuthStore();
   const pageTitle = customTitle || defaultTitle;
   const { isSearchOpen, toggleSearch, closeSearch } = useSearchStore();
   const { confirmNavigation } = useUnsavedChangesNavigation();
@@ -72,11 +72,7 @@ export default function Header() {
   }, [isNotificationOpen]);
 
 
-  const handleNavClick = (href: string, label: string) => {
-    if (label === "모임" && !isLoggedIn) {
-      openLoginModal();
-      return;
-    }
+  const handleNavClick = (href: string) => {
     confirmNavigation(() => router.push(href));
   };
   return (
@@ -111,7 +107,7 @@ export default function Header() {
                     href={item.href}
                     label={item.label}
                     active={active}
-                    onClick={() => handleNavClick(item.href, item.label)}
+                    onClick={() => handleNavClick(item.href)}
                   />
                 );
               })}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 비로그인 유저(Guest)의 모임(/groups) 탐색 경험 개선 및 접근 제어 로직 리팩토링을 진행했습니다.
기존에는 모임 탭 진입 시 전역 useEffect를 통해 비회원을 강제로 메인 화면으로 리다이렉트(Hard-Gating)하여, 모임 리스트조차 둘러볼 수 없는 UX적인 문제와 비로그인 상태에서 빈 화면이 나타나는 Cold Start 이슈가 있었습니다.
이를 **컴포넌트 레벨의 이벤트 인터셉션(Soft-Gating)**과 API Dual-Track 전략으로 개편하여, 누구나 자유롭게 모임을 탐색하되 실제 행동(방문, 가입, 생성 등)을 취할 때만 즉각적인 로그인 모달을 띄우도록 기술적 최적화를 완료했습니다.

- **공통 캐러셀 컴포넌트 개발**: Framer Motion을 기반으로 빈 여백이 발생하지 않는 `연속 기차(Continuous Track)` 원리의 `<SwipeCarousel />` 공통 컴포넌트를 신규 개발했습니다.
- **기존 페이지 리팩토링**: `NewsBannerSlider` 및 `NewsListBanner` 컴포넌트 내부에 중복되어 있던 슬라이더 로직을 모두 제거하고, 신규 공통 컴포넌트를 주입하여 유지보수성을 극대화했습니다.
- **실시간 반응형 버그 픽스**: 스와이프 중 인디케이터(점)가 뒤늦게 갱신되는 현상 및 방치 시 순서가 꼬이는 비동기 상태 엇갈림(Race Condition) 버그를 수정했습니다.

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 문서 업데이트
- [ ] 기타 (설명: )

## 📸 스크린샷 (Screenshots)


## ✅ 체크리스트 (Checklist)
- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [x] 린트 에러가 없나요? (`pnpm lint`)
- [x] 불필요한 콘솔 로그나 주석을 제거했나요?

---

## 🔬 기술적 상세 사항 (Technical Details)

### 1. 연속 트랙(Continuous Track) 및 가상화(Virtualization)
기존 `AnimatePresence` 방식은 카드가 교체되는 찰나에 DOM에서 카드가 지워지면서 하얀 여백이 노출되는 치명적 한계가 있었습니다. 이를 해결하기 위해 카드를 가로로 묶은 **연속 기차(Continuous Track)** 구조로 변경했습니다. 메모리 과부하를 막기 위해 실제 데이터가 수십 개여도, 트랙에는 단 3장(이전, 현재, 다음)만 절대 좌표로 띄워두고 재활용하는 **가상화(Virtualization)**를 적용했습니다.


### 2. 투 트랙(Two-Track) 렌더링 최적화
카드가 애니메이션으로 날아가는 도중에 React 상태 인덱스를 교체해버리면, 카드가 갑자기 눈앞에서 순간 이동을 하는 시각적 버그(Layout Shift)가 발생합니다. 하지만 인덱스 갱신을 늦추면 사용자 눈에 보이는 인디케이터(점)도 한 박자 늦게 켜지는 딜레마가 있습니다.
이를 **DOM 렌더링용 인덱스**와 **시각용 점등 인덱스**로 완전히 분리(Decoupling)하여 해결했습니다.

* **`renderIndex`**: DOM 카드 재배치용 (애니메이션 완료 후에만 안전하게 변경)
* **`indicatorIndex`**: 하단 점 표시용 (`useMotionValueEvent`로 x 좌표를 감시하여, 손가락으로 50% 이상 드래그 시 즉시 반응)

```mermaid
sequenceDiagram
    participant User as 사용자 (드래그)
    participant Motion as Framer Motion (x좌표)
    participant Indicator as indicatorIndex (점)
    participant Render as renderIndex (DOM)

    User->>Motion: 스와이프 발생
    Motion-->>Indicator: 실시간 x 좌표 1px 단위로 관찰
    
    alt x 좌표가 화면 너비의 절반(50%) 이상 넘어감
        Indicator->>Indicator: indicatorIndex 즉시 변경
        Note over Indicator: 하단 점(Dot) 즉각 불 켜짐!
    end

    Motion->>Motion: 카드 스냅 애니메이션 종료 (onComplete)
    Motion->>Render: renderIndex 업데이트 (DOM 교체)
    Render->>Indicator: 상태 최종 동기화 및 0점 정렬
```

### 3. 상태 엇갈림 버그(Race Condition) 동기적 해결
React의 비동기 업데이트 타이밍과 Framer Motion의 즉각적 이벤트 실행 타이밍 간의 경합 조건(Race Condition)으로 인해 점의 위치가 과거로 돌아가버리는 버그가 있었습니다.
`updateRenderIndex`라는 별도의 헬퍼 함수를 만들어, React 화면 렌더링 대기열에 들어가기 전에 **메모리(`useRef`)에 최신 인덱스를 동기적(Synchronous)으로 꽂아 넣는 기법**을 사용하여 상태 충돌을 원천 차단했습니다.

```mermaid
graph LR
    A[애니메이션 완료] -->|1. Ref에 즉시 주입| B(renderIndexRef.current = newIndex)
    B -->|2. React에 상태 갱신 예약| C(setRenderIndex)
    B -->|3. X 좌표 0으로 초기화| D[x.set 0]
    D -.->|4. X 변화 감지기 동기적 발동| E{X 감지기}
    E -->|이미 최신화된 Ref를 읽음!| F[올바른 점등 상태 유지]
    
    style B stroke:#ffeb3b,stroke-width:3px
```

### 4. 모바일 방어 대책 
- **스크롤 정크 완벽 차단**: 기차 트랙 컨테이너에 `touch-action: pan-y`를 부여하여 가로 스와이프 중에는 브라우저 세로 스크롤이 원천 차단되도록 했습니다. (모바일 네이티브와 동일한 터치감 확보)
- **고스트 이미지 차단**: 브라우저 기본 이미지 드래그 액션으로 인한 멈춤 현상을 막기 위해 `draggable={false}`, `pointer-events-none` 처리를 완료했습니다.

### 5. 전역 라우팅 가드 제거 및 컴포넌트 이벤트 인터셉션 패턴 도입
- 기존 Header와 GroupsPageClient 마운트 시 발생하던 강제 리다이렉션 로직을 제거했습니다. 대신 사용자가 의도를 가지고 액션을 취하는 시점(ex. onClickVisit, onClickApply)에 클라이언트 전역 상태(useAuthStore.getState().isLoggedIn)를 평가하여, 서버 에러(401)를 기다리지 않고 선제적으로 로그인 모달을 호출하는 패턴을 적용했습니다. 이를 통해 화면 깜빡임(Flicker) 없는 부드러운 UX를 달성했습니다.

### 6. Dual-Track 전략을 통한 비회원 초기 렌더링 최적화

백엔드의 /api/v1/clubs/recommendations API는 유저의 토큰을 기반으로 초개인화된 모임을 추천하므로 비회원에게는 401 에러를 반환합니다.
이에 isGuestDefaultView (비회원이면서 검색어가 없는 상태)라는 명시적인 뷰 렌더링 상태를 추가하고, 해당 상태일 경우 백엔드의 범용 검색 API(GET /api/v1/clubs/search?outputFilter=ALL)를 Fallback으로 호출하도록 React Query 옵션을 재조정했습니다.

### 7. 상세 페이지(/groups/:id) 단계적 권한 제어 (Progressive Gating)

방문하기 버튼 차단: 비회원이 방문하기 버튼 클릭 시 401 에러 화면이 나타나는 것을 막기 위해 진입 자체를 모달로 방어했습니다.
Home 탭 접근 완화: 로그인한 유저라면 해당 모임의 가입자가 아니더라도 Home 탭에서 모임 소개글을 확인하고 가입 신청을 할 수 있도록 layout.tsx의 useClubAccessGuard 권한을 완화했습니다.
내부 탭 철저 차단: Notice, Bookcase 등 멤버 전용 탭에 대해서만 렌더링 전에 requiresMemberAccess를 true로 설정하여 비정상적인 URL 접근을 원천 차단했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a swipeable, autoplaying carousel for news and promotion banners.
  * Unauthenticated visitors can now browse a guest-friendly groups view without being redirected.

* **Bug Fixes**
  * Improved login prompts for group actions like joining, following, creating, and opening restricted tabs.
  * Updated group search and “load more” behavior so guest browsing works consistently.
  * Simplified banner interactions for smoother swipe and tap navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->