### PR TITLE
fix: 한글 닉네임 입력 및 프로필 경로 지원

### DIFF
--- a/src/app/(admin)/admin/(app)/groups/[id]/members/page.tsx
+++ b/src/app/(admin)/admin/(app)/groups/[id]/members/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { encodeNicknamePathSegment } from "@/utils/nickname";
 import { useParams } from "next/navigation";
 import {
   fetchAdminClubActiveMembers,
@@ -202,7 +203,7 @@ export default function MembersListPage() {
                     <td className="pl-[12px] text-Gray-7">{u.role}</td>
                     <td className="pl-[12px]">
                       <Link
-                        href={`/admin/users/${u.nickname}`}
+                        href={`/admin/users/${encodeNicknamePathSegment(u.nickname)}`}
                         className="text-Gray-7 underline underline-offset-2 hover:opacity-70"
                       >
                         상세보기

--- a/src/app/(admin)/admin/(app)/users/page.tsx
+++ b/src/app/(admin)/admin/(app)/users/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import AdminSearchHeader from "@/components/layout/AdminSearchHeader";
 import Link from "next/link";
+import { encodeNicknamePathSegment } from "@/utils/nickname";
 import {
   fetchAdminMembers,
   type AdminMemberListItem,
@@ -137,7 +138,7 @@ export default function UsersPage() {
                     </td>
                     <td className="pl-[12px] py-0">
                       <Link
-                        href={`/admin/users/${u.nickname}`}
+                        href={`/admin/users/${encodeNicknamePathSegment(u.nickname)}`}
                         className="body_1_2 text-Gray-7 underline underline-offset-2 hover:opacity-70"
                       >
                         상세보기

--- a/src/app/(main)/books/[id]/BookDetailClient.tsx
+++ b/src/app/(main)/books/[id]/BookDetailClient.tsx
@@ -11,6 +11,7 @@ import { useToggleStoryLikeMutation } from "@/hooks/mutations/useStoryMutations"
 import { useToggleFollowMutation } from "@/hooks/mutations/useMemberMutations";
 import { useAuthAction } from "@/hooks/useAuthAction";
 import { showCustomToast } from "@/utils/toastUtils";
+import { getProfilePath } from "@/utils/nickname";
 
 export default function BookDetailClient() {
     const params = useParams();
@@ -110,7 +111,7 @@ export default function BookDetailClient() {
                         cardLayoutType="large-fixed"
                         onToggleLike={handleToggleStoryLike}
                         onToggleFollow={handleToggleFollow}
-                        onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+                        onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
                     />
                 </div>
             </div>

--- a/src/app/(main)/groups/[id]/admin/applicant/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/applicant/page.tsx
@@ -10,6 +10,7 @@ import { useUpdateClubMemberStatusMutation } from '@/hooks/mutations/useClubMemb
 import type { ClubMemberItem } from '@/types/groups/clubMembers';
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
 import MobileBackButton from '@/components/common/MobileBackButton';
+import { getProfilePath } from '@/utils/nickname';
 
 type ActionType = 'delete' | 'approve';
 
@@ -231,7 +232,7 @@ export default function AdminApplicantPage() {
   };
 
   const goProfile = (nickname: string) => {
-    router.push(`/profile/${nickname}`);
+    router.push(getProfilePath(nickname));
   };
 
   return (

--- a/src/app/(main)/groups/[id]/admin/members/page.tsx
+++ b/src/app/(main)/groups/[id]/admin/members/page.tsx
@@ -10,6 +10,7 @@ import { useInfiniteClubMembersQuery } from "@/hooks/queries/useClubMemberQuerie
 import { useClubMeQuery } from "@/hooks/queries/useClubhomeQueries";
 import { useUpdateClubMemberStatusMutation } from "@/hooks/mutations/useClubMemberMutations";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { getProfilePath } from "@/utils/nickname";
 import type {
   ClubMemberItem,
   ClubMemberStatus,
@@ -434,7 +435,7 @@ export default function AdminMembersPage() {
             <div className="divide-y divide-Subbrown-4 border-b border-Subbrown-4 overflow-visible">
               {currentMembers.map((member) => {
                 const nickname = member.detailInfo.nickname;
-                const profileUrl = `/profile/${encodeURIComponent(nickname)}`;
+                const profileUrl = getProfilePath(nickname);
                 const joinDate = formatDate(member.joinedAt ?? member.appliedAt);
 
                 return (

--- a/src/app/(main)/groups/[id]/bookcase/[bookId]/BookDetailPageClient.tsx
+++ b/src/app/(main)/groups/[id]/bookcase/[bookId]/BookDetailPageClient.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams, useParams } from "next/navigation";
 import toast from "react-hot-toast";
+import { getProfilePath } from "@/utils/nickname";
 
 import BookDetailCard from "@/components/base-ui/Bookcase/BookDetailCard";
 import BookDetailNav, { Tab as TabKey } from "@/components/base-ui/Bookcase/BookDetailNav";
@@ -189,7 +190,7 @@ export default function BookDetailPageClient() {
   }, [reviewsQuery.data]);
 
   const handleClickAuthor = (nickname: string) => {
-    confirmNavigation(() => router.push(`/profile/${nickname}`));
+    confirmNavigation(() => router.push(getProfilePath(nickname)));
   };
 
   const handleOpenTopicReport = (id: number | string) => {

--- a/src/app/(main)/home/HomePageClient.tsx
+++ b/src/app/(main)/home/HomePageClient.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from "@/store/useAuthStore";
 import { useRecommendedMembersQuery } from "@/hooks/queries/useMemberQueries";
 import { useMyClubsQuery } from "@/hooks/queries/useClubQueries";
 import { useHomeInteractions } from "@/hooks/useHomeInteractions";
+import { getProfilePath } from "@/utils/nickname";
 
 export default function HomePageClient() {
   const router = useRouter();
@@ -44,7 +45,7 @@ export default function HomePageClient() {
                   users={recommendedUsers}
                   isError={isErrorMembers}
                   isLoading={isLoadingMembers}
-                  onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+                  onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
                   onSubscribeClick={handleToggleFollow}
                 />
               </div>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from "@/store/useAuthStore";
 import { useRecommendedMembersQuery } from "@/hooks/queries/useMemberQueries";
 import { useMyClubsQuery } from "@/hooks/queries/useClubQueries";
 import { useHomeInteractions } from "@/hooks/useHomeInteractions";
+import { getProfilePath } from "@/utils/nickname";
 
 
 export default function HomePage() {
@@ -52,7 +53,7 @@ export default function HomePage() {
                 users={recommendedUsers}
                 isError={isErrorMembers}
                 isLoading={isLoadingMembers}
-                onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+                onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
                 onSubscribeClick={handleToggleFollow}
               />
             </div>

--- a/src/app/(main)/profile/[nickname]/ProfileClient.tsx
+++ b/src/app/(main)/profile/[nickname]/ProfileClient.tsx
@@ -12,6 +12,7 @@ import OtherUserProfileTabs from "@/components/base-ui/Profile/OtherUser/OtherUs
 import type { OtherProfileTabId } from "@/components/base-ui/Profile/OtherUser/OtherUserProfileTabs";
 import { useOtherProfileQuery } from "@/hooks/queries/useMemberQueries";
 import { getProfileAccessErrorMessage } from "@/utils/profileAccess";
+import { isSameNicknameIdentity } from "@/utils/nickname";
 
 const TAB_UNAVAILABLE_TARGET: Record<OtherProfileTabId, string> = {
   stories: "책 이야기를",
@@ -44,8 +45,7 @@ function ProfileTabLoadingMessage() {
   );
 }
 
-export default function ProfileClient({ encodedNickname }: { encodedNickname: string }) {
-  const nickname = encodedNickname ? decodeURIComponent(encodedNickname) : "";
+export default function ProfileClient({ nickname }: { nickname: string }) {
   const [activeTab, setActiveTab] = useState<OtherProfileTabId>("stories");
   const router = useRouter();
   const { user, isLoggedIn } = useAuthStore();
@@ -56,7 +56,7 @@ export default function ProfileClient({ encodedNickname }: { encodedNickname: st
     (profileQuery.isError ? "프로필 정보를 불러올 수 없습니다." : null);
 
   useEffect(() => {
-    if (isLoggedIn && user?.nickname && user.nickname === nickname) {
+    if (isLoggedIn && user?.nickname && isSameNicknameIdentity(user.nickname, nickname)) {
       router.replace("/profile/mypage");
     }
   }, [isLoggedIn, user?.nickname, nickname, router]);

--- a/src/app/(main)/profile/[nickname]/follows/NicknameFollowsClient.tsx
+++ b/src/app/(main)/profile/[nickname]/follows/NicknameFollowsClient.tsx
@@ -10,17 +10,20 @@ import { FollowUser } from "@/components/base-ui/Profile/Follow/FollowItem";
 import { useOtherProfileQuery, useFollowerListQuery, useFollowingListQuery } from "@/hooks/queries/useMemberQueries";
 import { useToggleFollowMutation } from "@/hooks/mutations/useMemberMutations";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { decodeNicknamePathSegment } from "@/utils/nickname";
 
 function OtherUserFollowsContent() {
     const router = useRouter();
     const params = useParams();
-    const nickname = params?.nickname as string;
-    const decodedNickname = decodeURIComponent(nickname || "");
+    const nicknameSegment = (params?.nickname as string) || "";
+    const nickname = nicknameSegment
+        ? decodeNicknamePathSegment(nicknameSegment)
+        : "";
     const searchParams = useSearchParams();
     const initialTab = (searchParams?.get("tab") as "follower" | "following") || "follower";
     const [activeTab, setActiveTab] = useState<"follower" | "following">(initialTab);
 
-    const { data: profileData, isLoading: isProfileLoading } = useOtherProfileQuery(decodedNickname);
+    const { data: profileData, isLoading: isProfileLoading } = useOtherProfileQuery(nickname);
 
     const {
         data: followerData,
@@ -28,7 +31,7 @@ function OtherUserFollowsContent() {
         hasNextPage: hasNextFollower,
         isFetchingNextPage: isFetchingNextFollower,
         isLoading: isFollowerLoading
-    } = useFollowerListQuery(decodedNickname, activeTab === "follower");
+    } = useFollowerListQuery(nickname, activeTab === "follower");
 
     const {
         data: followingData,
@@ -36,7 +39,7 @@ function OtherUserFollowsContent() {
         hasNextPage: hasNextFollowing,
         isFetchingNextPage: isFetchingNextFollowing,
         isLoading: isFollowingLoading
-    } = useFollowingListQuery(decodedNickname, activeTab === "following");
+    } = useFollowingListQuery(nickname, activeTab === "following");
 
     const { mutate: toggleFollow } = useToggleFollowMutation();
 
@@ -84,7 +87,7 @@ function OtherUserFollowsContent() {
 
     return (
         <div className="flex flex-col items-center gap-[10px] t:gap-[24px] w-full min-h-screen bg-[#F9F7F6] pb-[120px] t:pb-[100px]">
-            <ProfileBreadcrumb nickname={decodedNickname} />
+            <ProfileBreadcrumb nickname={nickname} />
 
             <div className="flex flex-col items-center w-full max-w-[1440px] px-4 md:px-0 mt-[12px] md:mt-[56px] gap-[24px]">
                 {/* Profile Image & Nickname Area */}

--- a/src/app/(main)/profile/[nickname]/page.tsx
+++ b/src/app/(main)/profile/[nickname]/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from "next";
 import ProfileClient from "./ProfileClient";
+import {
+  decodeNicknamePathSegment,
+  encodeNicknamePathSegment,
+} from "@/utils/nickname";
 
 type Props = { params: Promise<{ nickname: string }> };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { nickname: encodedNickname } = await params;
-  const nickname = decodeURIComponent(encodedNickname);
+  const { nickname: nicknameSegment } = await params;
+  const nickname = decodeNicknamePathSegment(nicknameSegment);
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/members/${encodedNickname}`, {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/members/${encodeNicknamePathSegment(nickname)}`, {
       next: { revalidate: 3600 },
     });
     if (!res.ok) return { title: `${nickname}의 프로필` };
@@ -28,6 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function OtherUserProfilePage({ params }: Props) {
-  const { nickname: encodedNickname } = await params;
-  return <ProfileClient encodedNickname={encodedNickname} />;
+  const { nickname: nicknameSegment } = await params;
+  const nickname = decodeNicknamePathSegment(nicknameSegment);
+  return <ProfileClient nickname={nickname} />;
 }

--- a/src/app/(main)/setting/profile/ProfileEditPageClient.tsx
+++ b/src/app/(main)/setting/profile/ProfileEditPageClient.tsx
@@ -10,13 +10,20 @@ import { useUpdateProfileMutation } from "@/hooks/mutations/useMemberMutations";
 import { authService } from "@/services/authService";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { clampTextToLimit, isTextOverLimit } from "@/utils/inputLimit";
+import {
+  isSameNicknameIdentity,
+  validateNickname,
+} from "@/utils/nickname";
 
 export default function ProfileEditPageClient() {
   const { user } = useAuthStore();
   const [nickname, setNickname] = useState(user?.nickname || "");
   // 현재 닉네임은 기본적으로 통과 상태(변경 시에만 중복확인 필요)
   const [isNicknameChecked, setIsNicknameChecked] = useState(true);
-  const [nicknameStatus, setNicknameStatus] = useState<"idle" | "available" | "duplicate">("idle");
+  const [nicknameStatus, setNicknameStatus] = useState<
+    "idle" | "available" | "duplicate" | "current"
+  >("idle");
+  const [nicknameInputError, setNicknameInputError] = useState("");
   const [intro, setIntro] = useState(user?.description || "");
   const [name, setName] = useState(user?.name || "");
   const [phone, setPhone] = useState(user?.phoneNumber || "");
@@ -42,9 +49,11 @@ export default function ProfileEditPageClient() {
 
   useEffect(() => {
     if (user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setNickname(user.nickname || "");
       setIsNicknameChecked(true);
       setNicknameStatus("idle");
+      setNicknameInputError("");
       setIntro(user.description || "");
       setName(user.name || "");
       setPhone(formatPhoneNumber(user.phoneNumber || ""));
@@ -53,31 +62,41 @@ export default function ProfileEditPageClient() {
     }
   }, [user]);
 
-  // 닉네임 입력: 영어 소문자/숫자/특수문자, 최대 20자 (회원가입 규칙과 동일)
   const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const filtered = e.target.value
-      .replace(/[^a-z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/g, "")
-      .slice(0, 20);
-    setNickname(filtered);
-    // 현재 닉네임과 같으면 통과, 다르면 중복확인 필요
-    setIsNicknameChecked(filtered === (user?.nickname || ""));
-    setNicknameStatus("idle");
+    const value = e.target.value;
+    const validation = validateNickname(value);
+    const isCurrentIdentity =
+      validation.isValid &&
+      isSameNicknameIdentity(validation.normalized, user?.nickname || "");
+
+    setNickname(value);
+    setNicknameInputError(value.length > 0 && !validation.isValid ? validation.message : "");
+    setIsNicknameChecked(isCurrentIdentity);
+    setNicknameStatus(isCurrentIdentity ? "current" : "idle");
   };
 
   const handleCheckNickname = async () => {
-    if (!nickname) {
-      toast.error("닉네임을 입력해주세요.");
+    const validation = validateNickname(nickname);
+    if (!validation.isValid) {
+      setNicknameInputError(validation.message);
+      toast.error(validation.message);
       return;
     }
-    // 본인 현재 닉네임이면 중복으로 처리하지 않음
-    if (nickname === (user?.nickname || "")) {
+
+    const normalizedNickname = validation.normalized;
+    if (normalizedNickname !== nickname) {
+      setNickname(normalizedNickname);
+    }
+
+    // 본인의 현재 닉네임과 대소문자만 다른 경우에도 중복확인을 통과한다.
+    if (isSameNicknameIdentity(normalizedNickname, user?.nickname || "")) {
       setIsNicknameChecked(true);
-      setNicknameStatus("idle");
+      setNicknameStatus("current");
       toast.success("현재 사용 중인 닉네임입니다.");
       return;
     }
     try {
-      const response = await authService.checkNickname(nickname);
+      const response = await authService.checkNickname(normalizedNickname);
       // result: false = 사용 가능, true = 중복
       if (response.isSuccess && response.result === false) {
         setIsNicknameChecked(true);
@@ -128,11 +147,15 @@ export default function ProfileEditPageClient() {
   };
 
   const handleSave = () => {
-    if (!nickname.trim()) {
-      toast.error("닉네임을 입력해주세요.");
+    const validation = validateNickname(nickname);
+    if (!validation.isValid) {
+      setNicknameInputError(validation.message);
+      toast.error(validation.message);
       return;
     }
-    const nicknameChanged = nickname !== (user?.nickname || "");
+
+    const normalizedNickname = validation.normalized;
+    const nicknameChanged = normalizedNickname !== (user?.nickname || "");
     if (nicknameChanged && !isNicknameChecked) {
       toast.error("닉네임 중복확인을 해주세요!");
       return;
@@ -147,7 +170,7 @@ export default function ProfileEditPageClient() {
       return;
     }
     updateProfile({
-      nickname,
+      nickname: normalizedNickname,
       description: intro,
       categories: selectedCategories,
       phoneNumber: phone,
@@ -173,6 +196,7 @@ export default function ProfileEditPageClient() {
     "flex items-center justify-center gap-[10px] rounded-[8px] border border-Subbrown-3 bg-Subbrown-4 h-[36px] w-[67px] md:h-[52px] md:w-[98px] xl:w-[132px]";
   const checkBtnTextClass =
     "text-primary-3 text-[12px] font-semibold leading-[145%] tracking-[-0.012px] md:body_1_3";
+  const isNicknameValid = validateNickname(nickname).isValid;
 
   return (
     <SettingsDetailLayout
@@ -198,23 +222,29 @@ export default function ProfileEditPageClient() {
                   className={inputClass}
                   value={nickname}
                   onChange={handleNicknameChange}
-                  placeholder="영어 소문자/숫자/특수문자, 최대 20자"
+                  placeholder="한글/영문/숫자/특수문자, 최대 20자"
                 />
               </div>
               <button
                 type="button"
                 onClick={handleCheckNickname}
-                disabled={!nickname || isNicknameChecked}
+                disabled={!isNicknameValid || isNicknameChecked}
                 className={`${checkBtnClass} shrink-0 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 <span className={checkBtnTextClass}>{isNicknameChecked ? "확인됨" : "중복확인"}</span>
               </button>
             </div>
-            {nickname !== (user?.nickname || "") && (
+            {nicknameInputError ? (
+              <span className="text-[12px] ml-1 text-red-500">
+                {nicknameInputError}
+              </span>
+            ) : nickname !== (user?.nickname || "") ? (
               <span
                 className={`text-[12px] ml-1 ${
                   nicknameStatus === "available"
                     ? "text-green-600"
+                    : nicknameStatus === "current"
+                      ? "text-green-600"
                     : nicknameStatus === "duplicate"
                       ? "text-red-500"
                       : "text-Gray-4"
@@ -222,11 +252,13 @@ export default function ProfileEditPageClient() {
               >
                 {nicknameStatus === "available"
                   ? "사용 가능한 닉네임입니다."
+                  : nicknameStatus === "current"
+                    ? "현재 닉네임과 같은 아이디입니다. 표시만 변경됩니다."
                   : nicknameStatus === "duplicate"
                     ? "이미 사용 중인 닉네임입니다."
                     : "닉네임 중복확인을 해주세요."}
               </span>
-            )}
+            ) : null}
           </div>
         </div>
 

--- a/src/app/(main)/stories/StoriesPageClient.tsx
+++ b/src/app/(main)/stories/StoriesPageClient.tsx
@@ -15,6 +15,7 @@ import { useToggleStoryLikeMutation } from "@/hooks/mutations/useStoryMutations"
 import { useToggleFollowMutation } from "@/hooks/mutations/useMemberMutations";
 
 import CategorySlider from "@/components/base-ui/BookStory/Common/CategorySlider";
+import { getProfilePath } from "@/utils/nickname";
 
 export default function StoriesPageClient() {
   const router = useRouter();
@@ -170,7 +171,7 @@ export default function StoriesPageClient() {
         fetchNextPage={fetchNextPage}
         onToggleLike={handleToggleLike}
         onToggleFollow={handleToggleFollow}
-        onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+        onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
         cardLayoutType="large-fixed"
         containerClassName="mt-6"
         gridClassName="flex flex-wrap gap-5 justify-center d:grid d:grid-cols-4 d:justify-items-center"
@@ -179,7 +180,7 @@ export default function StoriesPageClient() {
             <ListSubscribeLarge
               height="h-[380px]"
               users={recommendedMembers}
-              onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+              onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
               onSubscribeClick={(nickname, isFollowing) => handleToggleFollow(nickname, isFollowing)}
             />
           )

--- a/src/components/base-ui/Admin/stories/bookstory_detail.tsx
+++ b/src/components/base-ui/Admin/stories/bookstory_detail.tsx
@@ -11,6 +11,7 @@ import { ReportReason } from "@/types/report";
 import { useAuthStore } from "@/store/useAuthStore";
 import { toast } from "react-hot-toast";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { getProfilePath } from "@/utils/nickname";
 
 type BookstoryDetailProps = {
   imageUrl?: string;
@@ -77,7 +78,7 @@ export default function BookstoryDetail({
   hideSubscribeButton = false,
 }: BookstoryDetailProps) {
   const router = useRouter();
-  const href = authorHref ?? `/profile/${authorId}`;
+  const href = authorHref ?? getProfilePath(String(authorId));
   const [menuOpen, setMenuOpen] = useState(false);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);

--- a/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
+++ b/src/components/base-ui/BookStory/Detatil/bookstory_detail.tsx
@@ -9,6 +9,7 @@ import { ReportReason } from "@/types/report";
 import { useAuthStore } from "@/store/useAuthStore";
 import { toast } from "react-hot-toast";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { getProfilePath } from "@/utils/nickname";
 
 type BookstoryDetailProps = {
   imageUrl?: string;
@@ -79,7 +80,7 @@ export default function BookstoryDetail({
   onEditClick,
   onDeleteClick,
 }: BookstoryDetailProps) {
-  const href = authorHref ?? (isMyStory ? "/profile/mypage" : `/profile/${encodeURIComponent(authorId)}`);
+  const href = authorHref ?? (isMyStory ? "/profile/mypage" : getProfilePath(String(authorId)));
   const [menuOpen, setMenuOpen] = useState(false);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const mobileMenuRef = useRef<HTMLDivElement>(null);

--- a/src/components/base-ui/Bookcase/MeetingTeamMemberPopover.tsx
+++ b/src/components/base-ui/Bookcase/MeetingTeamMemberPopover.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useOnClickOutside } from "@/hooks/useOnClickOutside";
 import type { MeetingTeamMemberItem } from "@/types/groups/meetingDetail";
 import { getProfileImageSrc } from "@/utils/profileImage";
+import { getProfilePath } from "@/utils/nickname";
 
 type Props = {
   memberCount: number;
@@ -40,7 +41,7 @@ export default function MeetingTeamMemberPopover({
 
   const handleClickMember = (nickname: string) => {
     setIsOpen(false);
-    router.push(`/profile/${encodeURIComponent(nickname)}`);
+    router.push(getProfilePath(nickname));
   };
 
   return (

--- a/src/components/base-ui/Bookcase/bookid/TeamMemberItem.tsx
+++ b/src/components/base-ui/Bookcase/bookid/TeamMemberItem.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { getProfileImageSrc } from "@/utils/profileImage";
+import { getProfilePath } from "@/utils/nickname";
 
 type Props = {
   name: string;
@@ -15,7 +16,7 @@ export default function TeamMemberItem({
 }: Props) {
   return (
     <Link
-      href={`/profile/${encodeURIComponent(name)}`}
+      href={getProfilePath(name)}
       className="
         flex w-full items-center justify-between rounded-[8px] border border-Subbrown-4 bg-background px-[20px] py-[12px]
         transition-all duration-150 ease-out

--- a/src/components/base-ui/Comment/comment_section_bookcase.tsx
+++ b/src/components/base-ui/Comment/comment_section_bookcase.tsx
@@ -23,6 +23,7 @@ import { hasErrorCode } from "@/lib/api/errors";
 import { useUnsavedChangesNavigation } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { isTextOverLimit } from "@/utils/inputLimit";
+import { getProfilePath } from "@/utils/nickname";
 
 // 어떤 글의 댓글인지 구분
 type CommentSectionProps = {
@@ -288,7 +289,7 @@ export default function CommentSection({
         onEditComment={handleEditComment}
         onDeleteComment={handleDeleteComment}
         onReportComment={handleReportComment}
-        onProfileClick={(nickname) => confirmNavigation(() => router.push(`/profile/${nickname}`))}
+        onProfileClick={(nickname) => confirmNavigation(() => router.push(getProfilePath(nickname)))}
       />
       <ConfirmModal
         isOpen={isConfirmOpen}

--- a/src/components/base-ui/Comment/comment_section_notice.tsx
+++ b/src/components/base-ui/Comment/comment_section_notice.tsx
@@ -22,6 +22,7 @@ import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
 import { useUnsavedChangesNavigation } from "@/hooks/useUnsavedChangesGuard";
 import { INPUT_LIMITS } from "@/constants/inputLimits";
 import { isTextOverLimit } from "@/utils/inputLimit";
+import { getProfilePath } from "@/utils/nickname";
 
 type CommentSectionNoticeProps = {
   noticeId: number;
@@ -113,8 +114,8 @@ export default function CommentSectionNotice({
       });
 
       toast.success("댓글이 등록되었습니다.");
-    } catch (e: any) {
-      const msg = e?.message ?? "";
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "";
       toast.error(msg || "댓글 등록에 실패했습니다.");
     }
   };
@@ -150,8 +151,8 @@ export default function CommentSectionNotice({
       });
 
       toast.success("댓글이 수정되었습니다.");
-    } catch (e: any) {
-      const msg = e?.message ?? "";
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "";
       toast.error(msg || "댓글 수정에 실패했습니다.");
     }
   };
@@ -177,8 +178,8 @@ export default function CommentSectionNotice({
       });
 
       toast.success("댓글이 삭제되었습니다.");
-    } catch (e: any) {
-      const msg = e?.message ?? "";
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "";
       toast.error(msg || "댓글 삭제에 실패했습니다.");
     }
   };
@@ -242,7 +243,7 @@ export default function CommentSectionNotice({
         onEditComment={handleEditComment}
         onDeleteComment={handleDeleteComment}
         onReportComment={handleReportComment}
-        onProfileClick={(nickname) => confirmNavigation(() => router.push(`/profile/${nickname}`))}
+        onProfileClick={(nickname) => confirmNavigation(() => router.push(getProfilePath(nickname)))}
         onLoadMore={handleLoadMore}
         hasNextPage={!!commentsQuery.hasNextPage}
         isFetchingNextPage={!!commentsQuery.isFetchingNextPage}

--- a/src/components/base-ui/Group/notice_detail.tsx
+++ b/src/components/base-ui/Group/notice_detail.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/hooks/mutations/useClubNotificationMutations';
 import BookshelfDeleteConfirmModal from '../Bookcase/bookid/BookshelfDeleteConfirmModal';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
+import { getProfilePath } from '@/utils/nickname';
 
 type NoticeDetailProps = {
   clubId: number;
@@ -73,7 +74,7 @@ function VoteMemberPopover({
 
   const handleClickMember = (nickname: string) => {
     setIsOpen(false);
-    router.push(`/profile/${encodeURIComponent(nickname)}`);
+    router.push(getProfilePath(nickname));
   };
 
   return (
@@ -294,8 +295,8 @@ export default function NoticeDetail({
       toast.success(
         isRevoteMode ? '투표가 수정되었습니다.' : '투표가 완료되었습니다.'
       );
-    } catch (e: any) {
-      const msg = e?.message ?? '';
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '';
       toast.error(msg || '투표에 실패했습니다.');
     }
   };
@@ -325,8 +326,8 @@ export default function NoticeDetail({
       await deleteNotice({ clubId, noticeId });
       toast.success('공지사항이 삭제되었습니다.');
       router.push(`/groups/${clubId}/notice`);
-    } catch (e: any) {
-      const msg = e?.message ?? '';
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '';
       toast.error(msg || '공지사항 삭제에 실패했습니다.');
     } finally {
       setIsDeleteModalOpen(false);

--- a/src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts
+++ b/src/components/base-ui/Join/steps/ProfileImage/useProfileImage.ts
@@ -5,6 +5,7 @@ import { authService } from "@/services/authService";
 import { CATEGORY_MAP } from "@/constants/categories";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
 import { useAuthStore } from "@/store/useAuthStore";
+import { normalizeNickname } from "@/utils/nickname";
 
 export const useProfileImage = () => {
   const {
@@ -72,9 +73,10 @@ export const useProfileImage = () => {
 
       // 2. Submit all info to additional-info endpoint
       const categories = selectedInterests.map((c: string) => CATEGORY_MAP[c] || c);
+      const normalizedNickname = normalizeNickname(nickname);
 
       await authService.additionalInfo({
-        nickname,
+        nickname: normalizedNickname,
         name,
         phoneNumber,
         description,
@@ -85,7 +87,7 @@ export const useProfileImage = () => {
       const fallbackEmail = currentUser?.email || email;
       const fallbackUser = {
         email: fallbackEmail,
-        nickname,
+        nickname: normalizedNickname,
         name,
         phoneNumber,
         description,

--- a/src/components/base-ui/Join/steps/ProfileSetup/ProfileSetup.tsx
+++ b/src/components/base-ui/Join/steps/ProfileSetup/ProfileSetup.tsx
@@ -78,7 +78,7 @@ const ProfileSetup: React.FC<ProfileSetupProps> = ({ onNext }) => {
                       <JoinInput
                         value={nickname}
                         onChange={handleNicknameChange}
-                        placeholder="닉네임을 입력해주세요(최대 20글자)"
+                        placeholder="한글/영문/숫자/특수문자(최대 20자)"
                         className="h-[44px] border-Subbrown-4 placeholder-Gray-3 text-[14px] font-normal w-full bg-white"
                       />
                     </div>

--- a/src/components/base-ui/Join/steps/ProfileSetup/useProfileSetup.ts
+++ b/src/components/base-ui/Join/steps/ProfileSetup/useProfileSetup.ts
@@ -1,10 +1,16 @@
 import { useSignup } from "@/contexts/SignupContext";
 import { authService } from "@/services/authService";
+import { validateNickname } from "@/utils/nickname";
 import { useState } from "react";
 import { z } from "zod";
 
 const profileSchema = z.object({
-  nickname: z.string().min(1, "닉네임을 입력해주세요!"),
+  nickname: z.string().superRefine((value, ctx) => {
+    const validation = validateNickname(value);
+    if (!validation.isValid) {
+      ctx.addIssue({ code: "custom", message: validation.message });
+    }
+  }),
   isNicknameChecked: z.boolean().refine((val) => val === true, {
     message: "닉네임 중복확인을 해주세요!",
   }),
@@ -31,12 +37,11 @@ export const useProfileSetup = () => {
 
   const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    // 닉네임 : 영어 소문자 및 특수문자, 숫자만 사용 가능, 최대 20글자
-    const allowedValue = value.replace(/[^a-z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/g, "");
-    const filteredValue = allowedValue.slice(0, 20);
-    setNicknameInputError(value !== allowedValue ? "한글과 띄어쓰기는 사용할 수 없습니다." : "");
-    setNickname(filteredValue);
-    if (filteredValue !== nickname) {
+    const validation = validateNickname(value);
+
+    setNickname(value);
+    setNicknameInputError(value.length > 0 && !validation.isValid ? validation.message : "");
+    if (value !== nickname) {
       setIsNicknameChecked(false);
     }
   };
@@ -64,10 +69,20 @@ export const useProfileSetup = () => {
   };
 
   const handleCheckDuplicate = async () => {
-    if (!nickname) return;
+    const validation = validateNickname(nickname);
+    if (!validation.isValid) {
+      setNicknameInputError(validation.message);
+      showToast(validation.message);
+      return;
+    }
+
+    const normalizedNickname = validation.normalized;
+    if (normalizedNickname !== nickname) {
+      setNickname(normalizedNickname);
+    }
 
     try {
-      const response = await authService.checkNickname(nickname);
+      const response = await authService.checkNickname(normalizedNickname);
       // Backend Spec: result: false (not duplicated/available), result: true (duplicated/taken)
       if (response.isSuccess && response.result === false) {
         setIsNicknameChecked(true);
@@ -99,7 +114,7 @@ export const useProfileSetup = () => {
     return { isValid: true };
   };
 
-  const isNicknameValid = nickname.length > 0;
+  const isNicknameValid = validateNickname(nickname).isValid;
 
   return {
     nickname,

--- a/src/components/base-ui/Profile/Follow/FollowItem.tsx
+++ b/src/components/base-ui/Profile/Follow/FollowItem.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { isValidUrl } from "@/utils/url";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/images";
+import { getProfilePath } from "@/utils/nickname";
 
 export type FollowUser = {
     id: string | number;
@@ -37,7 +38,7 @@ export default function FollowItem({ user, onToggleFollow, onDelete, badge, subL
 
     return (
         <div className="flex w-full max-w-[1040px] p-[20px] justify-between items-center gap-[12px] rounded-[8px] border border-Subbrown-4 bg-White transition-colors hover:bg-Subbrown-5">
-            <Link href={`/profile/${user.nickname}`} className="group flex items-center gap-[12px] cursor-pointer min-w-0">
+            <Link href={getProfilePath(user.nickname)} className="group flex items-center gap-[12px] cursor-pointer min-w-0">
                 <div className="flex w-[40px] h-[40px] justify-center items-center shrink-0 rounded-full overflow-hidden relative">
                     <Image
                         src={isValidUrl(user.profileImageUrl) ? user.profileImageUrl : DEFAULT_PROFILE_IMAGE}

--- a/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
+++ b/src/components/base-ui/Profile/OtherUser/ProfileUserInfo.tsx
@@ -12,6 +12,7 @@ import ExpandableProfileImage from "@/components/common/ExpandableProfileImage";
 import { useReportBlockFlow } from "@/hooks/useReportBlockFlow";
 import { ReportReason } from "@/types/report";
 import { getProfileAccessErrorMessage } from "@/utils/profileAccess";
+import { getProfileFollowsPath } from "@/utils/nickname";
 
 // [보조 컴포넌트] 액션 버튼 (구독하기 / 신고하기)
 function ActionButton({
@@ -149,12 +150,12 @@ export default function ProfileUserInfo({ nickname }: { nickname: string }) {
                 <StatItem
                   label="구독중"
                   count={profile.followingCount}
-                  href={`/profile/${profile.nickname}/follows?tab=following`}
+                  href={getProfileFollowsPath(profile.nickname, "following")}
                 />
                 <StatItem
                   label="구독자"
                   count={profile.followerCount}
-                  href={`/profile/${profile.nickname}/follows?tab=follower`}
+                  href={getProfileFollowsPath(profile.nickname, "follower")}
                 />
               </div>
             </div>

--- a/src/components/base-ui/home/Story/HomeStoryList.tsx
+++ b/src/components/base-ui/home/Story/HomeStoryList.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from "@/store/useAuthStore";
 import { useRouter } from "next/navigation";
 import { RecommendedMember } from "@/types/member";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { getProfilePath } from "@/utils/nickname";
 
 interface HomeStoryListProps {
   recommendedUsers: RecommendedMember[];
@@ -60,7 +61,7 @@ const HomeStoryList: React.FC<HomeStoryListProps> = ({
       users={recommendedUsers}
       isError={isErrorMembers}
       isLoading={isLoadingMembers}
-      onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+      onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
       onSubscribeClick={onToggleFollow}
     />
   ) : undefined;
@@ -78,7 +79,7 @@ const HomeStoryList: React.FC<HomeStoryListProps> = ({
       fetchNextPage={fetchNextPage}
       onToggleLike={handleToggleLike}
       onToggleFollow={onToggleFollow}
-      onProfileClick={(nickname) => router.push(`/profile/${nickname}`)}
+      onProfileClick={(nickname) => router.push(getProfilePath(nickname))}
       cardLayoutType={cardLayoutType}
       containerClassName="flex flex-col items-center w-full max-w-full gap-[20px]"
       gridClassName={gridClassName}
@@ -91,4 +92,3 @@ const HomeStoryList: React.FC<HomeStoryListProps> = ({
 };
 
 export default HomeStoryList;
-

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -12,10 +12,14 @@ import {
   User
 } from "@/types/auth";
 import { LoginStatusResponse } from "@/types/member";
+import { normalizeNickname } from "@/utils/nickname";
 
 export const authService = {
   login: async (data: LoginForm): Promise<LoginResponse> => {
-    return await apiClient.post<LoginResponse>(AUTH_ENDPOINTS.LOGIN, data);
+    return await apiClient.post<LoginResponse>(AUTH_ENDPOINTS.LOGIN, {
+      ...data,
+      identifier: data.identifier.normalize("NFC"),
+    });
   },
 
   signup: async (data: SignupForm): Promise<ApiResponse<User>> => {
@@ -36,12 +40,15 @@ export const authService = {
 
   checkNickname: async (nickname: string): Promise<ApiResponse<boolean>> => {
     return await apiClient.post<ApiResponse<boolean>>(MEMBER_ENDPOINTS.CHECK_NICKNAME, null, {
-      params: { nickname }
+      params: { nickname: normalizeNickname(nickname) }
     });
   },
 
   additionalInfo: async (data: AdditionalInfo): Promise<ApiResponse<unknown>> => {
-    return await apiClient.post<ApiResponse<unknown>>(MEMBER_ENDPOINTS.ADDITIONAL_INFO, data);
+    return await apiClient.post<ApiResponse<unknown>>(MEMBER_ENDPOINTS.ADDITIONAL_INFO, {
+      ...data,
+      nickname: normalizeNickname(data.nickname),
+    });
   },
 
   getProfile: async (): Promise<ApiResponse<User>> => {

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -3,6 +3,7 @@ import { MEMBER_ENDPOINTS } from "@/lib/api/endpoints/member";
 import { RecommendResponse, UpdateProfileRequest, UpdatePasswordRequest, ProfileResponse, OtherProfileResponse, FollowListResponse, FollowCountResponse, FindEmailRequest, FindEmailResponse, LoginStatusResponse, UpdateEmailRequest, BlockListResponse } from "@/types/member";
 import { ReportRequest, MyReportList } from "@/types/report";
 import { ApiResponse, TermsResponse, MemberTermsStatus, UpdateAgreementsRequest } from "@/types/auth";
+import { normalizeNickname } from "@/utils/nickname";
 export const memberService = {
     getRecommendedMembers: async (): Promise<RecommendResponse> => {
         const response = await apiClient.get<ApiResponse<RecommendResponse>>(
@@ -13,7 +14,10 @@ export const memberService = {
     updateProfile: async (data: UpdateProfileRequest): Promise<void> => {
         const response = await apiClient.patch<ApiResponse<unknown>>(
             MEMBER_ENDPOINTS.UPDATE_PROFILE,
-            data
+            {
+                ...data,
+                nickname: data.nickname ? normalizeNickname(data.nickname) : data.nickname,
+            }
         );
         if (!response.isSuccess) {
             throw new Error(response.message || "Failed to update profile");

--- a/src/utils/nickname.ts
+++ b/src/utils/nickname.ts
@@ -1,0 +1,76 @@
+export const NICKNAME_MAX_LENGTH = 20;
+
+const ALLOWED_NICKNAME_PATTERN =
+  /^[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>/?]+$/u;
+
+export type NicknameValidationResult = {
+  isValid: boolean;
+  normalized: string;
+  message: string;
+};
+
+export const normalizeNickname = (nickname: string): string =>
+  nickname.normalize("NFC");
+
+export const getNicknameComparisonKey = (nickname: string): string =>
+  normalizeNickname(nickname).toLowerCase();
+
+export const isSameNicknameIdentity = (
+  first: string,
+  second: string
+): boolean => {
+  const firstKey = getNicknameComparisonKey(first);
+  return firstKey.length > 0 && firstKey === getNicknameComparisonKey(second);
+};
+
+export const validateNickname = (nickname: string): NicknameValidationResult => {
+  const normalized = normalizeNickname(nickname);
+
+  if (normalized.length === 0) {
+    return {
+      isValid: false,
+      normalized,
+      message: "닉네임을 입력해주세요.",
+    };
+  }
+
+  if (/\s/u.test(normalized)) {
+    return {
+      isValid: false,
+      normalized,
+      message: "닉네임에는 공백을 사용할 수 없습니다.",
+    };
+  }
+
+  if ([...normalized].length > NICKNAME_MAX_LENGTH) {
+    return {
+      isValid: false,
+      normalized,
+      message: `닉네임은 최대 ${NICKNAME_MAX_LENGTH}자까지 가능합니다.`,
+    };
+  }
+
+  if (!ALLOWED_NICKNAME_PATTERN.test(normalized)) {
+    return {
+      isValid: false,
+      normalized,
+      message: "닉네임은 한글, 영문, 숫자, 허용된 특수문자만 사용할 수 있습니다.",
+    };
+  }
+
+  return { isValid: true, normalized, message: "" };
+};
+
+export const encodeNicknamePathSegment = (nickname: string): string =>
+  encodeURIComponent(normalizeNickname(nickname));
+
+export const decodeNicknamePathSegment = (nickname: string): string =>
+  decodeURIComponent(nickname);
+
+export const getProfilePath = (nickname: string): string =>
+  `/profile/${encodeNicknamePathSegment(nickname)}`;
+
+export const getProfileFollowsPath = (
+  nickname: string,
+  tab: "follower" | "following"
+): string => `${getProfilePath(nickname)}/follows?tab=${tab}`;

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,4 +1,5 @@
 import { NotificationBasicInfo } from "@/types/notification";
+import { getProfilePath } from "@/utils/nickname";
 
 export const getNotificationText = (notification: NotificationBasicInfo): string => {
     const name = notification.displayName;
@@ -26,7 +27,7 @@ export const getNotificationRedirectUrl = (notification: NotificationBasicInfo):
         case "COMMENT":
             return `/stories/${notification.domainId}`;
         case "FOLLOW":
-            return `/profile/${encodeURIComponent(notification.displayName)}`;
+            return getProfilePath(notification.displayName);
         case "JOIN_CLUB":
         case "CLUB_MEETING_CREATED":
         case "CLUB_NOTICE_CREATED":


### PR DESCRIPTION
## 📌 개요 (Summary)

- 회원가입과 프로필 편집에서 한글 및 영문 대문자 닉네임을 입력할 수 있도록 변경했습니다.
- 백엔드 닉네임 정책과 동일하게 NFC 정규화와 대소문자 무시 비교를 적용했습니다.
- 한글 및 허용 특수문자가 포함된 닉네임으로 프로필 이동이 가능하도록 URL 경로 처리를 보완했습니다.
- 관련 이슈: Closes #515

## 🛠 변경 사항 (Changes)

- [x] 새로운 기능 추가
  - 한글 완성형 및 한글 호환 자모 입력 지원
  - 영문 대문자 입력 지원
  - 본인의 닉네임 대소문자만 변경하는 경우 중복확인 자동 통과
- [x] 버그 수정
  - 잘못된 문자를 자동 삭제하지 않고 검증 오류를 표시하도록 변경
  - 한글 및 `/`, `%`, `?`, `#` 등 허용 특수문자가 포함된 프로필 경로 인코딩 처리
  - 동적 프로필 경로를 진입 시 한 번만 디코딩하도록 수정
- [x] 코드 리팩토링
  - 닉네임 검증·NFC 정규화·대소문자 비교·URL 경로 처리를 공통 유틸리티로 분리
  - 회원가입과 프로필 편집에서 동일한 닉네임 정책을 사용하도록 통일
- [ ] 문서 업데이트
- [ ] 기타

## 📸 스크린샷 (Screenshots)

- UI 구조 변경은 없으며 닉네임 입력 규칙과 오류 안내 동작만 변경했습니다.

## ✅ 체크리스트 (Checklist)

- [x] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
  - 변경 파일 대상 ESLint는 오류 없이 통과했습니다.
  - 전체 린트는 이번 작업과 무관하게 기존 파일에 남아 있는 오류로 실패합니다.
- [x] 불필요한 콘솔 로그나 주석을 추가하지 않았나요?
- [x] 타입 검사가 통과했나요? (`pnpm type-check`)
- [x] 한글·영문 대소문자·공백·백틱·`~`·이모지 입력 사례를 확인했습니다.
- [x] 한글, `%`, `/`가 포함된 프로필 경로의 인코딩·디코딩을 확인했습니다.