### PR TITLE
fix: 홈 캐러셀에 PROMOTION 필터 및 publishEndAt 정렬 추가 (#517)

### DIFF
--- a/src/components/base-ui/home/News/NewsBannerSlider.tsx
+++ b/src/components/base-ui/home/News/NewsBannerSlider.tsx
@@ -10,7 +10,11 @@ export default function NewsBannerSlider() {
   const newsList = data?.pages.flatMap((page) => page.basicInfoList) || [];
   
   const carouselItems = useMemo(() => {
-    return newsList.slice(0, 5).map((news) => {
+    return newsList
+      .filter((news) => news.carousel === "PROMOTION")
+      .sort((a, b) => new Date(b.publishEndAt).getTime() - new Date(a.publishEndAt).getTime())
+      .slice(0, 5)
+      .map((news) => {
       const isValidSrc = news.thumbnailUrl && news.thumbnailUrl !== "string" && 
         (news.thumbnailUrl.startsWith("/") || news.thumbnailUrl.startsWith("http"));
         


### PR DESCRIPTION
- 홈 화면 NewsBannerSlider에 carousel === 'PROMOTION' 필터 누락 수정
- 소식 화면 NewsListBanner와 동일하게 publishEndAt 내림차순 정렬 적용
- RN HomeScreen.tsx의 필터 로직과 일치시킴

## 📌 개요 (Summary)
- 변경 사항에 대한 간략한 요약을 적어주세요.
- 관련 이슈가 있다면 링크를 걸어주세요 (예: #123).

## 🛠️ 변경 사항 (Changes)
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명: )

## 📸 스크린샷 (Screenshots)
(UI 변경 사항이 있다면 첨부해주세요)

## ✅ 체크리스트 (Checklist)
- [ ] 빌드가 성공적으로 수행되었나요? (`pnpm build`)
- [ ] 린트 에러가 없나요? (`pnpm lint`)
- [ ] 불필요한 콘솔 로그나 주석을 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the news banner to display only promotional news.
  * Sorted banners by latest publication end time.
  * Limited the banner display to a maximum of five items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->